### PR TITLE
Extended mode - allows pjax requests to update more than one container

### DIFF
--- a/README
+++ b/README
@@ -93,14 +93,15 @@ The $(link).pjax() function accepts a container, an options object,
 or both. The options are the same as jQuery's $.ajax options with the
 following additions:
 
-container - The selector of the container to load the reponse body into, or
-            the container itself.
-     push - Whether to pushState the URL. Defaults to true (of course).
-  replace - Whether to replaceState the URL. Defaults to false.
-  timeout - pjax sets this low, <1s. Set this higher if using a custom
-            error handler. It's in ms, so something like `timeout: 2000`
-    error - By default this callback reloads the target page once `timeout`
-            ms elapses.
+    container - The selector of the container to load the reponse body into, or
+                the container itself.
+         push - Whether to pushState the URL. Defaults to true (of course).
+      replace - Whether to replaceState the URL. Defaults to false.
+      timeout - pjax sets this low, <1s. Set this higher if using a custom
+                error handler. It's in ms, so something like `timeout: 2000`
+        error - By default this callback reloads the target page once `timeout`
+                ms elapses.
+beforeSuccess - Callback to execute before the new content is put on the page.
 
 
 ## $.pjax( options )

--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -88,6 +88,7 @@ jQuery.pjax = function( options ) {
       xhr.setRequestHeader('X-PJAX', 'true')
     },
     error: function(){ window.location = options.url },
+    beforeSuccess: function() { },
     success: function( data ) {
       var state = { pjax: true };
       try {
@@ -114,6 +115,9 @@ jQuery.pjax = function( options ) {
       } catch (e) {
         return window.location = options.url;
       }
+
+      //Now we're certain that this is a valid response
+      this.beforeSuccess();
 
       if ( data.title ) document.title = data.title;
       $.each(data.containers, function (selector, html) {


### PR DESCRIPTION
Extended mode allows several containers to be updated with a
single request to the server. This is possible by having the
server do a bit more work and return a more meaningful response.

To go into extended mode don't specify a container when making
the request. In this case, the server needs to return a JSON response
specifying which containers to update, what page title to set, etc.

Normal mode should work as it used to, without being affected by this.
