### PR TITLE
Prevent error messages in IE8  when checking for the state property of the event object

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -200,7 +200,7 @@ $(window).bind('popstate', function(event) {
 
 // Add the state property to jQuery's event object so we can use it in
 // $(window).bind('popstate')
-if ( $.event.props.indexOf('state') < 0 )
+if ( $.inArray($.event.props, 'state') < 0 )
   $.event.props.push('state')
 
 


### PR DESCRIPTION
Use jQuery.inArray() rather than the native indexOf() method to check for the state property on jQuery's event object.

indexOf() was causing error messages in IE8.

pjax is the biz. love it.
