### PR TITLE
Added beforeSuccess option to $.pjax.

### DIFF
--- a/README
+++ b/README
@@ -80,6 +80,9 @@ following additions:
                     error handler. It's in ms, so something like `timeout: 2000`
             error - By default this callback reloads the target page once `timeout`
                     ms elapses.
+    beforeSuccess - Callback to execute before the new content is put on the page.
+                    If it returns true, pjax will apply the content, otherwise
+                    it will ignore it.
 
 
 ## $.pjax( options )

--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -91,6 +91,7 @@ $.pjax = function( options ) {
     error: function(){
       window.location = options.url
     },
+    beforeSuccess: function () { },
     complete: function(){
       $container.trigger('end.pjax')
     },
@@ -99,6 +100,9 @@ $.pjax = function( options ) {
       // to the page and let normal error handling happen.
       if ( !$.trim(data) || /<html/i.test(data) )
         return window.location = options.url
+
+      if ( this.beforeSuccess() === false )
+        return;
 
       // Make it happen.
       $container.html(data)


### PR DESCRIPTION
The callback will be executed before $.pjax applies the response data
for a given request, but only if the response data looks valid.
This allows you to do some stuff before the content in the container
gets replaced.
If the beforeSuccess callback returns false, pjax will not perform
any changes to the page.
