### PR TITLE
Make calls to $.pjax in older browsers trigger a full page reload.

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -206,7 +206,7 @@ if ( $.inArray('state', $.event.props) < 0 )
 
 // Fall back to normalcy for older browsers.
 if ( !window.history || !window.history.pushState ) {
-  $.pjax = $.noop
+  $.pjax = function ( options ) { window.location = options.url }
   $.fn.pjax = function() { return this }
 }
 


### PR DESCRIPTION
This used to be a noop, meaning that it's unreliable to ever use
$.pjax directly in such browsers (but only through $.fn.pjax).
