### PR TITLE
more robust determination for pushState availability

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -217,7 +217,7 @@ var pushStateEnabled = Boolean(
 );
 
 // Fall back to normalcy for older browsers.
-if ( !window.history || !pushStateEnabled ) {
+if ( !pushStateEnabled ) {
   $.pjax = $.noop
   $.fn.pjax = function() { return this }
 }


### PR DESCRIPTION
currently, pjax uses window.history.pushState to determine whether or not the client is capable. this is an issue on certain browsers because although they expose the pushState method, it doesn't act particularly as expected.

one way this manifests itself in pjax is that the back button completely fails on iOS versions earlier than 4.3. i found a bit more about this on [a stackoverflow post](http://stackoverflow.com/questions/6161701/is-history-api-broken-on-ios-location-bar-doesnt-update-on-pushstate).

instead of checking for pushState, i added augmented the check with some user agent detection (which i stole from [another library](https://github.com/balupton/history.js)). this way, clients to pjax can still use $.pjax == $.noop to determine functionality.

thanks kindly...
