### PR TITLE
Fixed bug related to hashes in the URL; added 'fragment' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ following additions:
 
 * `container`      - The String selector of the container to load the
                      reponse body. Must be a String.
+* `fragment`      -  A jQuery String selector that selects a sub-element to
+                     be pulled out of the response HTML and inserted 
+                     into the `container`. Useful if the server always returns
+                     full HTML pages.
 * `clickedElement` - The element that was clicked to start the pjax call.
 * `push`           - Whether to pushState the URL. Default: true (of course)
 * `replace`        - Whether to replaceState the URL. Default: false

--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -45,7 +45,8 @@ $.fn.pjax = function( container, options ) {
     var defaults = {
       url: this.href,
       container: $(this).attr('data-pjax'),
-      clickedElement: $(this)
+      clickedElement: $(this),
+      fragment: null
     }
 
     $.pjax($.extend({}, defaults, options))
@@ -107,10 +108,17 @@ $.pjax = function( options ) {
       $container.trigger('end.pjax')
     },
     success: function(data){
-      // If we got no data or an entire web page, go directly
-      // to the page and let normal error handling happen.
-      if ( !$.trim(data) || /<html/i.test(data) )
-        return window.location = options.url
+      if (options.fragment) {
+        var $fragment = $(data).find(options.fragment)
+        if ($fragment.length)
+          data = $fragment.children()
+        else return window.location = options.url
+      } else {
+          // If we got no data or an entire web page, go directly
+          // to the page and let normal error handling happen.
+          if ( !$.trim(data) || /<html/i.test(data) )
+            return window.location = options.url          
+      }
 
       // Make it happen.
       $container.html(data)
@@ -123,6 +131,7 @@ $.pjax = function( options ) {
 
       var state = {
         pjax: options.container,
+        fragment: options.fragment,
         timeout: options.timeout
       }
 
@@ -202,6 +211,7 @@ $(window).bind('popstate', function(event){
     if ( $(container+'').length )
       $.pjax({
         url: state.url || location.href,
+        fragment: state.fragment,
         container: container,
         push: false,
         timeout: state.timeout


### PR DESCRIPTION
Thank you for a great plugin!

I made two changes:

https://github.com/mkai/jquery-pjax/commit/a9ec689ff3492cd6fa6384b26311a7a040b96776
Fix a bug that caused the back button to fail working after navigating to a URL containing a hash

Using a different method to reset the hash; the previous method, which reset window.location.hash, caused an empty hash ('#') to remain in the URL (which caused the back button to fail)

https://github.com/mkai/jquery-pjax/commit/5cb24ea44aea7be1dd5e4a83d3196e04ed7e1dd0
Added a 'fragment' option to support servers that always return full HTML pages

The 'fragment' option allows specifying a string selector which selects an element to be pulled out of the received response HTML. This is useful if you have no influence on the server side or do not want to modify the backend application. For example, 'fragment: "#content"' pulls the content element out of the response and inserts its children into the container element that you chose.
