### PR TITLE
Enable arbitrary JSON data to be returned along with the HTML

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -124,7 +124,7 @@ $.pjax = function( options ) {
       }
 
       // Make it happen.
-      $container.html(data)
+      $container.html(this.dataType === 'json' ? data.html : data)
 
       // If there's a <title> tag in the response, use it as
       // the page's title.


### PR DESCRIPTION
I've found it necessary in certain cases to return additional data along with the HTML. Until now I've been doing something like this:
#### HTML

```
<content>
  ...
</content>
<div id="foo" data-value="123"></div>
<div id="bar" data-value="false"></div>
```
#### JavaScript

```
foo = $el.find('#foo').remove().data('value') // 123
bar = $el.find('#bar').remove().data('value') // false
```

HTML is not a good format for transferring key–value data from server to client. JSON is.

To have pjax request JSON responses, set `dataType` to "json" in the options hash. (Ensure that the server uses "html" as the key for the HTML chunk in the JSON response.)
