### PR TITLE
Elements with no href or an anchor href should be ignored.

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -41,6 +41,11 @@ $.fn.pjax = function( container, options ) {
     // links in a new tab as normal.
     if ( event.which > 1 || event.metaKey )
       return true
+    
+    // Elements with no href or an anchor href should be ignored.
+    var href = $(event.target).attr('href')
+    if ( !href || href.indexOf('#') == 0 )
+      return true
 
     var defaults = {
       url: this.href,


### PR DESCRIPTION
I ran into this issue while trying to use the jquery-ui datepicker; clicking a day would fire off pjax and because all those elements are dynamically created there's no easy way to back out.
