### PR TITLE
Set page title from fragment's `title` or `data-title` attribute.

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,8 @@ Asp.Net MVC3: <http://biasecurities.com/blog/2011/using-pjax-with-asp-net-mvc3/>
 ## page titles
 
 Your HTML should also include a `<title>` tag if you want page titles to work.
+When using a page fragment, pjax will also check the fragment DOM element
+for a `title` or `data-title` attribute.
 
 
 ## events

--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -127,9 +127,14 @@ $.pjax = function( options ) {
       $container.html(data)
 
       // If there's a <title> tag in the response, use it as
-      // the page's title.
+      // the page's title. Also check the title and data-title attributes on
+      // the fragment element.
       var oldTitle = document.title,
           title = $.trim( $container.find('title').remove().text() )
+      if ( options.fragment ) {
+        if ( !title ) title = $fragment.attr('title')
+        if ( !title ) title = $fragment.data('title')
+      }
       if ( title ) document.title = title
 
       var state = {


### PR DESCRIPTION
When using a page fragment, pjax will also check the fragment DOM element for a `title` or `data-title` attribute. This is useful because the `<title>` element is (very probably) not available in this case.
