### PR TITLE
Drop focus on link after page loads

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -160,6 +160,9 @@ var pjax = $.pjax = function( options ) {
       window.location.href = hash
     }
 
+    // If the clicked element is still present, un-focus it
+    options.clickedElement.blur();
+
     // Invoke their success handler if they gave us one.
     success.apply(this, arguments)
   }


### PR DESCRIPTION
I'm using pjax to load a section of the page that does not include the links being clicked ([here's my site](http://www.iangreenleaf.com/)). Firefox gives focus to a link when it's clicked (other browsers do not), and without a full page reload that focus sticks around, leaving a dotted border on the link. I could hide the focus styling entirely, but I'd like to leave it for accessibility and all that.

Am I just using pjax in a weird way? I noticed your example page reloads the nav section as well. You can decide if this quirk is really pjax's problem to deal with or not.
