### PR TITLE
Assign document.title after examining attributes in the response.

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -118,12 +118,13 @@ var pjax = $.pjax = function( options ) {
     // the page's title.
     var oldTitle = document.title,
         title = $.trim( this.find('title').remove().text() )
-    if ( title ) document.title = title
 
     // No <title>? Fragment? Look for data-title and title attributes.
     if ( !title && options.fragment ) {
       title = $fragment.attr('title') || $fragment.data('title')
     }
+
+    if ( title ) document.title = title
 
     var state = {
       pjax: options.container,


### PR DESCRIPTION
The assignment to document.title should be placed here, or we cannot assign it from attributes.
