### PR TITLE
Support pushState on iOS 5

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -249,8 +249,8 @@ if ( $.inArray('state', $.event.props) < 0 )
 // Is pjax supported by this browser?
 $.support.pjax =
   window.history && window.history.pushState && window.history.replaceState
-  // pushState isn't reliable on iOS yet.
-  && !navigator.userAgent.match(/(iPod|iPhone|iPad|WebApps\/.+CFNetwork)/)
+  // pushState isn't reliable on iOS until 5.
+  && !navigator.userAgent.match(/((iPod|iPhone|iPad).+\bOS\s+[1-4]|WebApps\/.+CFNetwork)/)
 
 
 // Fall back to normalcy for older browsers.


### PR DESCRIPTION
iOS support was revoked in issue #38, but iOS 5 seems to be stable. I've changed the user-agent regexp to fit this.
