### PR TITLE
Set pjax.active to true when pjax is called with replace enabled

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -137,6 +137,7 @@ var pjax = $.pjax = function( options ) {
       state.url = options.url + (/\?/.test(options.url) ? "&" : "?") + query
 
     if ( options.replace ) {
+      pjax.active = true
       window.history.replaceState(state, document.title, options.url)
     } else if ( options.push ) {
       // this extra replaceState before first push ensures good back


### PR DESCRIPTION
This fixes the history when the first pjax call runs a replaceState.

Use case: the page loads and immediately after loads a container with pjax with the replace option on, replacing the URL in history for future navigation. Without this fix the history is broken.
