### PR TITLE
Ignore cross origin and same page anchors

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -42,6 +42,10 @@ $.fn.pjax = function( container, options ) {
     if ( event.which > 1 || event.metaKey )
       return true
 
+    // Ignore cross origin links
+    if ( location.protocol !== this.protocol || location.host !== this.host )
+      return true
+
     // Ignore anchors on the same page
     if ( this.hash && this.href.replace(this.hash, '') ===
          location.href.replace(location.hash, '') )


### PR DESCRIPTION
I would have said yagni to this before, but its pretty nice to be able to pjax all the links with `$('a').pjax()`.

Examples to skip:
- `http://google.com/`
- `#section`
- `javascript:alert()`

Resolves #53, #55
