### PR TITLE
Flexible options.container

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -183,6 +183,8 @@ function findContainerFor(container) {
     throw "no pjax container for " + container.selector
   } else if ( container.selector !== '' && container.context === document ) {
     return container
+  } else if ( container.attr('id') ) {
+    return $('#' + container.attr('id'))
   } else {
     throw "cant get selector for pjax container!"
   }


### PR DESCRIPTION
Makes it possible to pass in a few other types to `options.container` other than a String.

Example:

```
<div id="main"></div>
```

```
$('a').pjax('#main') // String - current behavior
$('a').pjax($('#main')) // jQuery object - uses .selector
$('a').pjax($('#main')[0]) // Element - works cause main is an id
```
