### PR TITLE
ignore clicks leading to the same page

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -63,6 +63,10 @@ function handleClick(event, container, options) {
   if ( location.protocol !== link.protocol || location.host !== link.host )
     return
 
+  // Ignore clicks leading to the same page
+  if ( location.href == link.href)
+    return false
+
   // Ignore anchors on the same page
   if ( link.hash && link.href.replace(link.hash, '') ===
        location.href.replace(location.hash, '') )

--- a/test/unit/fn_pjax.js
+++ b/test/unit/fn_pjax.js
@@ -167,6 +167,23 @@ if ($.support.pjax) {
     start()
   })
 
+
+  asyncTest("ignores exactly same uri", function() {
+    var frame = this.frame
+
+    frame.$("a").pjax({ container: "#main" })
+
+    var event = frame.$.Event('click')
+    frame.$('#main').on('pjax:end', function() {
+      ok(false)
+    })
+
+    frame.$("a[href='/home.html']").trigger(event)
+    equal(event.result, false)
+
+    start()
+  })
+
   asyncTest("ignores same page anchors", function() {
     var frame = this.frame
 

--- a/test/views/home.erb
+++ b/test/views/home.erb
@@ -5,6 +5,7 @@
   <li><a href="/dinosaurs.html">dinosaurs</a></li>
   <li><a href="/aliens.html">aliens</a></li>
   <li><a href="https://www.google.com/">Google</a></li>
+  <li><a href="/home.html">Same Page</a></li>
   <li><a href="#main">Main</a></li>
 </ul>
 


### PR DESCRIPTION
If we click on a link which leads to the same page as where we currently are, ignore it to avoid a useless call.
