### PR TITLE
Adding X-PJAX-Container header.

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -165,7 +165,7 @@ var pjax = $.pjax = function( options ) {
     }
 
     xhr.setRequestHeader('X-PJAX', 'true')
-    xhr.setRequestHeader('X-PJAX-Container', options.container)
+    xhr.setRequestHeader('X-PJAX-Container', options.context.selector)
     var result
 
     // DEPRECATED: Invoke original `beforeSend` handler

--- a/test/unit/pjax.js
+++ b/test/unit/pjax.js
@@ -140,6 +140,21 @@ if ($.support.pjax) {
     })
   })
 
+  asyncTest("sets X-PJAX-Container header to container selector on XHR request", function() {
+    var frame = this.frame
+
+    frame.$.pjax({
+      url: "env.html",
+      container: $("#main"),
+      success: function() {
+        var env = JSON.parse(frame.$("#env").text())
+        ok(env['HTTP_X_PJAX_CONTAINER'])
+        equal(env['HTTP_X_PJAX_CONTAINER'], "#main")
+        start()
+      }
+    })
+  })
+
 
   asyncTest("sets hidden _pjax param on XHR GET request", function() {
     var frame = this.frame


### PR DESCRIPTION
I find this useful. It lets the server discern the target container, and as such what 'level' of content that needs rednering into it. Usefull for sub navs and multple containers on a page. 
