### PR TITLE
data-pjax-loader support

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -462,3 +462,21 @@ if ( !$.support.pjax ) {
 }
 
 })(jQuery);
+
+
+$(function () {
+  $("a[data-pjax]").pjax();
+	$(document).on("pjax:start", function (e) {
+		var link = $(e.relatedTarget);
+		var linkTarget = $(link).attr("data-pjax-loader");
+		if (linkTarget) {
+			$(linkTarget).show()
+		}
+	}).on("pjax:end", function (e) {
+		var link = $(e.relatedTarget);
+		var linkTarget = $(link).attr("data-pjax-loader");
+		if (linkTarget) {
+			$(linkTarget).hide()
+		}
+	});
+});


### PR DESCRIPTION
Added data-pjax-loader support to display little progress bar, autobind pAjax with data-pjax attribute
eg.

<div id='main'>
  <div id='loader' class='loader' style='display:none'><img src='spin.gif'></div>
  <div class='tabs'>
    <a href='/explore' data-pjax='#main' data-pjax-loader="#loader">Explore</a>
    <a href='/help'>Help</a>
  </div>
</div>


Demo available at http://portfolio.lucemorker.com/
