### PR TITLE
Added hook to rewrite urls if sent through pjax

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -134,6 +134,8 @@ var pjax = $.pjax = function( options ) {
     options.url = options.url()
   }
 
+  options.url = options.urlMapper(url);
+
   var target = options.target
 
   // DEPRECATED: use options.target
@@ -371,6 +373,7 @@ pjax.defaults = {
   // pjax'd partial page loads and one for normal page loads. Without
   // adding this secret parameter, some browsers will often confuse the two.
   data: { _pjax: true },
+  urlMapper: function (url) { return url; },
   type: 'GET',
   dataType: 'html'
 }


### PR DESCRIPTION
I have a site that has its templates compiled ahead of time, served via nginx. I'd like to use pjax and have the component (pjax'd) templates at a different URL than the default link hrefs, decided by a rule.

This proposal is to add a urlMapper option that takes the original URL and returns a new URL. It is only called if pjax is going to be initiated.
