### PR TITLE
Sendind info about container to server

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -93,6 +93,8 @@ function stripPjaxParam(url) {
   return url
     .replace(/\?_pjax=true&?/, '?')
     .replace(/_pjax=true&?/, '')
+    .replace(/\?_pjax_container=true&?/, '?')
+    .replace(/_pjax_container=true&?/, '')
     .replace(/[\?&]$/, '')
 }
 
@@ -151,6 +153,8 @@ var pjax = $.pjax = function( options ) {
 
   var context = options.context = findContainerFor(options.container)
 
+  options.data._pjax_container = context.selector
+
   function fire(type, args) {
     var event = $.Event(type, { relatedTarget: target })
     context.trigger(event, args)
@@ -173,6 +177,7 @@ var pjax = $.pjax = function( options ) {
     }
 
     xhr.setRequestHeader('X-PJAX', 'true')
+    xhr.setRequestHeader('X-PJAX-CONTAINER', this.selector)
 
     var result
 


### PR DESCRIPTION
It's very useful to send selector of container to server. For example if I have pjax-links in main menu and I have pagination via pjax on the one of the pages, links in main menu should update full page and links for pagination should update only paginated part of page. So if I get selector of container, I can render only needed part of page. It's a bit better way than use 'fragment' option.
