### PR TITLE
back button doesn't change HTTP_REFERER

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -154,6 +154,7 @@ var pjax = $.pjax = function( options ) {
 
     xhr.setRequestHeader('X-PJAX', 'true')
     xhr.setRequestHeader('X-PJAX-Container', context.selector)
+    xhr.setRequestHeader('X-PJAX-Referer', settings.referer || window.location.href)
 
     var result
 
@@ -596,6 +597,7 @@ $(window).bind('popstate', function(event){
         url: state.url,
         container: container,
         push: false,
+        referer: pjax.state.url,
         fragment: state.fragment,
         timeout: state.timeout,
         scrollTo: false


### PR DESCRIPTION
Suppose you're on _page 1_. You click pjax link and go to _page 2_. You click browser's back button to go back to _page 1_. Now, you click pjax link to _page 3_. The _Referer_ header will be _page 2_ even though the referer should be _page 1_. 

I'm using Google Chrome 18 on Mac OS X 10.7.3.
It works fine in firefox 12.
