### PR TITLE
Ignore empty anchors on the same page

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -65,10 +65,17 @@ function handleClick(event, container, options) {
   if ( location.protocol !== link.protocol || location.host !== link.host )
     return
 
-  // Ignore anchors on the same page
-  if ( link.hash && link.href.replace(link.hash, '') ===
-       location.href.replace(location.hash, '') )
-    return
+  if ( link.hash ) {
+    // Ignore anchors on the same page
+    if ( link.href.replace(link.hash, '') ===
+         location.href.replace(location.hash, '') )
+      return
+  } else {
+    // Ignore trailing (empty) anchors on the same page (href="(.*)#"),
+    // which get treated differently (link.hash = '', link.href ends with a #)
+    if ( link.href === location.href + '#' )
+      return
+  }
 
   var defaults = {
     url: link.href,


### PR DESCRIPTION
Trailing (empty) anchors get treated differently and were not ignored
when PJAXing, like other anchor links for the same page.

For links with regular non-empty anchors, link.hash is something like
'#hash' and link.href is just the plain URI without the hash.

For links with an empty anchor (trailing #), link.hash is empty ('') and
link.href contains the original URI with the trailing # in it.

This patch adds some additional logic to catch that second special case.

Here's an example that illustrates the problem and its solution - http://jsfiddle.net/dY6te/1/
We're looking at the first link, the special case, which wouldn't normally be ignored by PJAX.
