### PR TITLE
Adds ability to replace the ajax container with the content, rather than putting it inside the container

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -217,7 +217,9 @@ var pjax = $.pjax = function( options ) {
 
     if (container.title) document.title = container.title
     if (options.replaceContainer) {
-    	context.replaceWith(container.contents);
+    	c = $(container.contents);
+    	context.replaceWith(c);
+    	context = c;
     } else {
     	context.html(container.contents)
     }
@@ -619,7 +621,9 @@ $(window).bind('popstate', function(event){
 
         if (state.title) document.title = state.title
         if (options.replaceContainer) {
-        	container.replaceWith(contents);
+        	c = $(contents);
+	    	container.replaceWith(c);
+	    	container = c;
         } else {
         	container.html(contents);
         }


### PR DESCRIPTION
I have found that with some widget designs the ability to replace the entire container, rather than just what is in the container can be benificial, especially with widgets. This is so future PJAX requests can know the container they were rendered in without having to store dynamic ids in the $_SESSION.

In the true spirit of open source I decided to commit it on the off-chance this would be useful to someone else...
