### PR TITLE
Small solution to combat issues with certain Pop-up blockers.

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -224,7 +224,12 @@ var pjax = $.pjax = function( options ) {
 
     // Scroll to top by default
     if (typeof options.scrollTo === 'number')
-      $(window).scrollTop(options.scrollTo)
+      try {
+        $(window).scrollTop(options.scrollTo)
+      }
+      catch (err) {
+        console.log(err.message);
+      }
 
     // Google Analytics support
     if ( (options.replace || options.push) && window._gaq )


### PR DESCRIPTION
Some pop-up blockers aggressively override functions like .scrollTo() with null and because of this, jquery-pjax is breaking in Chrome and is unable to fire pjax:end, pjax:success, etc. events when the error is thrown.

This is just a simple try/catch/log to deal with the issue as the problem is not with jquery-pjax, but still will hinder visitors and users of the site's pjax requests that don't realize that they need to disable the pop-up blocking browser extension.

If you can think of a preferred method of handling the issue, I would be glad to implement it for you. If you feel that the issue shouldn't be handled by jquery-pjax at all and rather by the extension developers in question themselves, that is acceptable as well. The issue is fixed on my machines which is all I presently care about.

(_Better Pop Up Blocker_ for Chrome is the extension that was causing the issue for me.)
