### PR TITLE
Refactored findAll(), fixes issue #170

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -525,7 +525,7 @@ function findContainerFor(container) {
 //
 // Returns a jQuery object.
 function findAll(elems, selector) {
-  return elems.find('*').andSelf().filter(selector);
+  return elems.filter(selector).add(elems.find(selector));
 }
 
 // Internal: Extracts container and metadata from response.


### PR DESCRIPTION
I believe this fixes the getAttribute() problem identified in [issue #170](https://github.com/defunkt/jquery-pjax/issues/170). From what I could tell, this error was happening with jQuery 1.8.0 when specifying a fragment option.

In the findAll() function, checking to see if newline ("\n") TextNodes matched the selector was causing jQuery to choke. I'm pretty sure that finding all descendants, [adding self](http://api.jquery.com/andSelf/), then filtering all of these by the desired selector seems to accomplish the same thing findAll() was doing without all the weird-ass getAttribute errors.
