### PR TITLE
Will behave like $.load by default

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -579,6 +579,10 @@ function extractContainer(data, xhr, options) {
   // the page's title.
   obj.title = findAll($head, 'title').last().text()
 
+  // If a full html doc is received, handle it like $.load
+  if (!options.fragment && $head !== $body)
+    options.fragment = options.container.selector;
+
   if (options.fragment) {
     // If they specified a fragment, look for it in the response
     // and pull it out.


### PR DESCRIPTION
If a `fragment` argument isn't supplied and the fetched content turns out to be a full html document, use the `container.selector` as the fragment to snag the section someone wants to replace. This makes more sense than fetching the document with ajax but then just redirecting to the destination url anyway.
