### PR TITLE
Don’t override default Shift + click and Alt + click behavior

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -66,7 +66,7 @@ function handleClick(event, container, options) {
 
   // Middle click, cmd click, and ctrl click should open
   // links in a new tab as normal.
-  if ( event.which > 1 || event.metaKey || event.ctrlKey )
+  if ( event.which > 1 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey )
     return
 
   // Ignore cross origin links


### PR DESCRIPTION
Shift and Alt modifiers do nifty things in various browsers:
- Shift + click:
  -  Safari: add a link to Reading List
  -  Chrome and Firefox: open a link in new window
-  Alt + click:
  -  Chrome: download a link
  -  Safari: same as Shift + click
- Alt + Shift + click:
  -  Safari: download a link
