### PR TITLE
When options.fragment is 'body', now will use body.contents from response, rather than the contents of the body's first child.

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -589,7 +589,11 @@ function extractContainer(data, xhr, options) {
     }
 
     if ($fragment.length) {
-      obj.contents = $fragment.contents()
+      // If the fragment was the body, then the contents in the fragment itself.
+      if (options.fragment === 'body')
+        obj.contents = $fragment;
+      else
+        obj.contents = $fragment.contents();
 
       // If there's no title, look for data-title and title attributes
       // on the fragment


### PR DESCRIPTION
I couldn't get it pjax working with full html responses.  I just wanted pjax to replace the title and body with the title and the body of the response.  This seems like a simple use case.  

However, in the extractContainer function, if options.fragment === 'body' and the response is a full html response, here's what I was seeing:

$body is set to the inner contents (essentially innerHTML)of the response's body, which is the array of child elements inside body.
$fragment is set to $body, which is misleading because it's actually the inner contents of the body, not the body element itself. 
obj.contents is set to $fragment.contents(), which was, I believe, getting the inner contents of each element in this array.

Instead, in the special case where $fragment is the inner contents of body, you want to just use $fragment itself, not $fragment.contents().
