### PR TITLE
Fix problems when there are multiple different data-pjax container values

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -30,10 +30,10 @@
 function fnPjax(selector, container, options) {
   var context = this
   return this.on('click.pjax', selector, function(event) {
-    options = optionsFor(container, options)
-    if (!options.container)
-      options.container = $(this).attr('data-pjax') || context
-    handleClick(event, options)
+    var opts = $.extend({}, optionsFor(container, options))
+    if (!opts.container)
+      opts.container = $(this).attr('data-pjax') || context
+    handleClick(event, opts)
   })
 }
 


### PR DESCRIPTION
This fixes problems where there are multiple links each with different
containers specified in their 'data-pjax' option. Once the first link is
clicked it sets the options.container value which is used by all
subsequent clicks.

This only occurs if a value is passed for the options parameter.

`$(document).pjax('a[data-pjax]', { timeout: 5000})` will cause problems
but just `$(document).pjax('a[data-pjax]')` will not.

The fix simply clones the options to avoid changing the original
parameter values
