### PR TITLE
Add ability to pass jQuery object in initializer

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -33,7 +33,7 @@ function fnPjax(selector, container, options) {
     var opts = $.extend({}, optionsFor(container, options))
     if (!opts.container)
       opts.container = $(this).attr('data-pjax') || context
-    handleClick(event, opts)
+    handleClick.call(this, event, opts)
   })
 }
 
@@ -59,8 +59,10 @@ function fnPjax(selector, container, options) {
 function handleClick(event, container, options) {
   options = optionsFor(container, options)
 
-  var link = event.currentTarget
+  var link = event[$(event.target).is("a") ? "target" : "currentTarget"]
 
+  if (link === event.delegateTarget)
+    return
   if (link.tagName.toUpperCase() !== 'A')
     throw "$.fn.pjax or $.pjax.click requires an anchor element"
 


### PR DESCRIPTION
Currently, when calling the initializer and passing a jQuery collection as the first argument, the event fails to run properly because it throws an error when the event.currentTarget is not an anchor. To be more jQuery-like, this initializer should accept both a selector string and a jQuery object.
