### PR TITLE
Fire passed in ajax callbacks

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -163,6 +163,7 @@ function pjax(options) {
   var hash = parseURL(options.url).hash
 
   var context = options.context = findContainerFor(options.container)
+  var callbacks = $.extend({}, options)
 
   // We want the browser to maintain two separate internal caches: one
   // for pjax'd partial page loads and one for normal page loads.
@@ -205,6 +206,7 @@ function pjax(options) {
       return false
 
     options.requestUrl = parseURL(settings.url).href
+    callbacks.beforeSend && callbacks.beforeSend.apply(this, arguments)
   }
 
   options.complete = function(xhr, textStatus) {
@@ -214,6 +216,7 @@ function pjax(options) {
     fire('pjax:complete', [xhr, textStatus, options])
 
     fire('pjax:end', [xhr, options])
+    callbacks.complete && callbacks.complete.apply(this, arguments)
   }
 
   options.error = function(xhr, textStatus, errorThrown) {
@@ -222,6 +225,7 @@ function pjax(options) {
     var allowed = fire('pjax:error', [xhr, textStatus, errorThrown, options])
     if (textStatus !== 'abort' && allowed)
       locationReplace(container.url)
+    callbacks.error && callbacks.error.apply(this, arguments)
   }
 
   options.success = function(data, status, xhr) {
@@ -275,6 +279,7 @@ function pjax(options) {
     }
 
     fire('pjax:success', [data, status, xhr, options])
+    callbacks.success && callbacks.success.apply(this, arguments)
   }
 
 


### PR DESCRIPTION
The documentation on the $.pjax method currently states: "It acts much like $.ajax, even returning the same thing and accepting the same options.". If you pass an options object in with success, error, complete, or beforeSend callbacks, however, they are overwritten after the options object is extended, deleting the callbacks passed in.
