### PR TITLE
fix Issue #147 

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -274,6 +274,9 @@ function pjax(options) {
       if (target.length) $(window).scrollTop(target.offset().top)
     }
 
+    // Cache current container element before replacing it
+    cachePush(pjax.state.id, context.clone().contents());
+
     fire('pjax:success', [data, status, xhr, options])
   }
 
@@ -306,9 +309,6 @@ function pjax(options) {
 
   if (xhr.readyState > 0) {
     if (options.push && !options.replace) {
-      // Cache current container element before replacing it
-      cachePush(pjax.state.id, context.clone().contents())
-
       window.history.pushState(null, "", stripPjaxParam(options.requestUrl))
     }
 


### PR DESCRIPTION
cache container element when pjax:success, 
Then when container changes, go back history will replace the current content.
