### PR TITLE
Provides a strategy for providing additional data to pjax.

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -238,7 +238,8 @@ function pjax(options) {
       title: container.title,
       container: context.selector,
       fragment: options.fragment,
-      timeout: options.timeout
+      timeout: options.timeout,
+      data: xhr.getResponseHeader('X-PJAX-DATA')
     }
 
     if (options.push || options.replace) {


### PR DESCRIPTION
Using an X-PJAX-DATA response header you can provide additional information to pjax that will persist in the history state.  I'm using this to pass back JSON which is then parsed and used to set a class on the body etc.  It works on history as well as ajax requests.  An example of how I'm using it:

```
$(document).pjax('a', container: '#content').on 'pjax:end', ->
  try data = JSON.parse($.pjax.state.data)
  catch e then data = {}
  // do whatever you'd like with your data.
```
