### PR TITLE
Fix pjax.reload after a pjax.disable

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -716,7 +716,8 @@ function disable() {
   $.pjax.disable = $.noop
   $.pjax.click = $.noop
   $.pjax.submit = $.noop
-  $.pjax.reload = window.location.reload
+  $.pjax.reload = function () {window.location.reload()}
+
   $(window).unbind('popstate.pjax', onPjaxPopstate)
 }
 


### PR DESCRIPTION
This does not currently work on IE/Safari/Chrome:

```
$.pjax.disable(); $.pjax.reload({container: '[data-pjax-container']})
```

This patch simply wraps the native reload and ignores any params, which seems to work.
