### PR TITLE
Normalize form method default to uppercase

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -118,7 +118,7 @@ function handleSubmit(event, container, options) {
     throw "$.pjax.submit requires a form element"
 
   var defaults = {
-    type: form.method,
+    type: form.method.toUpperCase(),
     url: form.action,
     data: $(form).serializeArray(),
     container: $(form).attr('data-pjax'),


### PR DESCRIPTION
In several places, PJAX checks the type (form method) of the current request against "GET". For pjax.submit, the default for this option is read from the submitted FORM element. At least for some versions of Firefox (e.g. 16.x), this property is always returned in lowercase.

This patch normalizes the method/type default to uppercase.
