### PR TITLE
Maintain text at top level after title removal

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -611,7 +611,7 @@ function extractContainer(data, xhr, options) {
   // Clean up any <title> tags
   if (obj.contents) {
     // Remove any parent title elements
-    obj.contents = obj.contents.not('title')
+    obj.contents = obj.contents.not(function() { return $(this).is('title') })
 
     // Then scrub any titles from their descendents
     obj.contents.find('title').remove()

--- a/test/unit/pjax.js
+++ b/test/unit/pjax.js
@@ -35,6 +35,7 @@ if ($.support.pjax) {
 
     frame.$('#main').on('pjax:success', function() {
       equal(frame.$("#main > p").html().trim(), "Hello!")
+      equal(frame.$("#main").contents().eq(1).text().trim(), "How's it going?")
       start()
     })
     frame.$.pjax({

--- a/test/views/hello.erb
+++ b/test/views/hello.erb
@@ -1,3 +1,4 @@
 <%= title 'Hello' %>
 <p>Hello!</p>
+How's it going?
 <script type="text/javascript">window.parent.iframeLoad(window)</script>


### PR DESCRIPTION
I noticed that when pjax received a response it was stripping any plain text at the top level of the DOM. This is due to the fact that JQuery's `.not()` only returns parent nodes and ignores the text. Using a function there resolves the issue.
