### PR TITLE
Always fall back to $body if no fragment specified

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -604,7 +604,7 @@ function extractContainer(data, xhr, options) {
         obj.title = $fragment.attr('title') || $fragment.data('title')
     }
 
-  } else if (!/<html/i.test(data)) {
+  } else {
     obj.contents = $body
   }
 


### PR DESCRIPTION
Since we're now testing whether `<html>` exists [here](https://github.com/defunkt/jquery-pjax/blob/master/jquery.pjax.js#L573-L579):

``` javascript
  // Attempt to parse response html into elements
  if (/<html/i.test(data)) {
    var $head = $($.parseHTML(data.match(/<head[^>]*>([\s\S.]*)<\/head>/i)[0]))
    var $body = $($.parseHTML(data.match(/<body[^>]*>([\s\S.]*)<\/body>/i)[0]))
  } else {
    var $head = $body = $($.parseHTML(data))
  }
```

There's no need for this else if. It was causing problems with the automatic `<body>` extraction, since it was impossible to populate `obj.contents` without a fragment specified.
