### PR TITLE
Allow a pjax update to eval scripts[src=..] returned in the body

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -246,17 +246,18 @@ function pjax(options) {
     if (container.title) document.title = container.title
     context.html(container.contents)
 
-	container.scripts.each(function(_, script) {
-	  var $script = $(script)
-	  var src = $script.attr('src')
-	  var target = document.head || context.get(0)
-	  var tag = document.createElement('script')
-	  tag.type = $script.attr('type') || "text/javascript"
-	  tag.async = false
-	  tag.src  = src
-	  if(!$('script[src="' + src + '"]').length)
-		target.appendChild(tag)
-	})
+  container.scripts.each(function(_, script) {
+    var $script = $(script)
+    var src = $script.attr('src')
+    if($('script[src="' + src + '"]').length) return
+
+    var target = document.head || context.get(0)
+    var tag = document.createElement('script')
+    tag.type = $script.attr('type') || "text/javascript"
+    tag.async = false
+    tag.src  = src
+    target.appendChild(tag)
+  })
 
     // Scroll to top by default
     if (typeof options.scrollTo === 'number')


### PR DESCRIPTION
First attempt #255 failed CI and was closed. 

This implements the same idea in a less noisy and, at least locally, CI :+1: way.

This extracts `script[src]` tags from the response body right away and removes them as children. 

After the body is `$.html`'ed into the DOM, the script tags are written out to either `document.head`, if available, or the current `context`, where the original body was written. If a tag with a matching `src=` attribute is found, it is not written again.
