### PR TITLE
Use hostname instead of host

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -70,7 +70,7 @@ function handleClick(event, container, options) {
     return
 
   // Ignore cross origin links
-  if ( location.protocol !== link.protocol || location.host !== link.host )
+  if ( location.protocol !== link.protocol || location.hostname !== link.hostname )
     return
 
   // Ignore anchors on the same page


### PR DESCRIPTION
Contrary to `location.host`, `link.host` may also return the port number at the end, so the condition fails.
