### PR TITLE
New Google Analytic library support. 

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -271,9 +271,13 @@ function pjax(options) {
     if (typeof options.scrollTo === 'number')
       $(window).scrollTop(options.scrollTo)
 
-    // Google Analytics support
+    // Old style Google Analytics ga.js support
     if ( (options.replace || options.push) && window._gaq )
       _gaq.push(['_trackPageview'])
+    // New Google analytics.js support
+    if ( (options.replace || options.push) && window.ga ) {
+      ga('send', 'pageview')
+    }
 
     // If the URL has a hash in it, make sure the browser
     // knows to navigate to the hash.


### PR DESCRIPTION
Google Analytics is recommending new users to use its
`analytics.js` instead of the old `ga.js` library.
The new library has a different way to send hits back,
hence the patch to support it.
https://developers.google.com/analytics/devguides/collection/analyticsjs/
