### PR TITLE
Add support for new style Google Analytics

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -276,8 +276,11 @@ function pjax(options) {
       _gaq.push(['_trackPageview'])
     // New Google analytics.js support
     if ( (options.replace || options.push) && window.ga ) {
-      var location = window.location.protocol + '//' + window.location.hostname + window.location.pathname + window.location.search;
-      ga('send', 'pageview', location)
+      var location = window.location.pathname + window.location.search;
+      ga('send', 'pageview', {
+        'page': location,
+        'title': document.title
+      });
     }
 
     // If the URL has a hash in it, make sure the browser


### PR DESCRIPTION
Google released a new way to add google analytics to your site (https://developers.google.com/analytics/devguides/collection/analyticsjs/advanced)

This removes _gaq from the global scope, and adds ga.

According to the documentation of Google, by default, when calling the ga('send','pageview') it should send the current url based on:

``` javascript
var location = window.location.protocol +
    '//' + window.location.hostname +
    window.location.pathname +
    window.location.search;
```

However, during testing I noticed it doesn't update when navigating using pjax. I provided a fix, by providing the location as extra parameter.
