### PR TITLE
Fix back button issue

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -172,8 +172,12 @@ function pjax(options) {
   // for pjax'd partial page loads and one for normal page loads.
   // Without adding this secret parameter, some browsers will often
   // confuse the two.
-  if (!options.data) options.data = []
-  options.data.push({name: '_pjax', value: context.selector})
+  if (!options.data) options.data = {}
+  if ($.isArray(options.data)) {
+    options.data.push({name: '_pjax', value: context.selector})
+  } else {
+    options.data._pjax = context.selector
+  }
 
   function fire(type, args) {
     var event = $.Event(type, { relatedTarget: target })


### PR DESCRIPTION
How to reproduce an error: 
- Click pjax link
- Click normal link
- Click "Back"

Expected: page should successfully load

What really happened: only pjax partial was loaded 

Reason: adding `_pjax` param to pjax request was broken. 

Why:  plugin threats `options.data` as hash `{}` but it's array: http://api.jquery.com/serializeArray/
