### PR TITLE
Eval script that doesn't contain type attr

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -678,8 +678,12 @@ function executeScriptTags(scripts) {
     if (matchedScripts.length) return
 
     var script = document.createElement('script')
-    script.type = $(this).attr('type')
+
+    var type = $(this).attr('type')
+    if( type ) script.type = type
+
     script.src = $(this).attr('src')
+
     document.head.appendChild(script)
   })
 }

--- a/test/evaled.js
+++ b/test/evaled.js
@@ -1,2 +1,5 @@
-window.evaledSrcScript = true
-window.evaledScriptLoaded()
+window.evaledSrcScriptNum = window.evaledSrcScriptNum || 0
+window.evaledSrcScriptNum++
+
+if (window.evaledSrcScriptNum === 2)
+  window.evaledScriptLoaded()

--- a/test/unit/pjax.js
+++ b/test/unit/pjax.js
@@ -123,7 +123,7 @@ if ($.support.pjax) {
     var frame = this.frame
 
     frame.evaledScriptLoaded = function() {
-      equal(true, frame.evaledSrcScript)
+      equal(2, frame.evaledSrcScriptNum)
       equal(true, frame.evaledInlineScript)
       start()
     }

--- a/test/views/scripts.erb
+++ b/test/views/scripts.erb
@@ -1,4 +1,5 @@
 <p>Got some script tags here</p>
 <script type="text/javascript" src="/test/evaled.js"></script>
+<script src="/test/evaled.js"></script>
 <script type="text/javascript">window.evaledInlineScript = true</script>
 <script type="text/javascript">window.parent.iframeLoad(window)</script>


### PR DESCRIPTION
If you don't specify the type of the script (i.e. `<script
src="..."></script>`), then (instead of setting the type attribute to
"undefined") evaluating the script without the type specification.
