### PR TITLE
Replace the bind() and unbind() aliases for the on() and off() functions...

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -779,7 +779,7 @@ function enable() {
     maxCacheLength: 20,
     version: findVersion
   }
-  $(window).bind('popstate.pjax', onPjaxPopstate)
+  $(window).on('popstate.pjax', onPjaxPopstate)
 }
 
 // Disable pushState behavior.
@@ -802,7 +802,7 @@ function disable() {
   $.pjax.submit = $.noop
   $.pjax.reload = function() { window.location.reload() }
 
-  $(window).unbind('popstate.pjax', onPjaxPopstate)
+  $(window).off('popstate.pjax', onPjaxPopstate)
 }
 
 


### PR DESCRIPTION
....

This is done in order to leverage jquery custom builds without the
event-alias module, which removes the bind() and unbind() aliases.

See: https://github.com/jquery/jquery/commit/100d3c351604e1f9641098da2e78678b4e6d9cdf
