### PR TITLE
Don't replace state on initialization when called directly with either push or replace option set to false

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -306,7 +306,9 @@ function pjax(options) {
       fragment: options.fragment,
       timeout: options.timeout
     }
-    window.history.replaceState(pjax.state, document.title)
+    if (options.push || options.replace) {
+      window.history.replaceState(pjax.state, document.title)
+    }
   }
 
   // Cancel the current request if we're already pjaxing


### PR DESCRIPTION
Calling $.pjax({url: ..., container: ..., replace: false, push: false}) was still doing a replaceState call during the initialization stage
