### PR TITLE
Saved the user's success callback. 

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -227,7 +227,11 @@ function pjax(options) {
     }
   }
 
-  options.success = function(data, status, xhr) {
+  // Save user callback
+  var _success = options.success || null;
+
+  options.success = (function(){
+    return function(data, status, xhr) {
     // If $.pjax.defaults.version is a function, invoke it first.
     // Otherwise it can be a static string.
     var currentVersion = (typeof $.pjax.defaults.version === 'function') ?
@@ -290,7 +294,13 @@ function pjax(options) {
     }
 
     fire('pjax:success', [data, status, xhr, options])
+
+    if(_success){
+      _success(data, status, xhr, options);
+    }
   }
+
+  })(_success);
 
 
   // Initialize pjax.state for the initial page load. Assume we're


### PR DESCRIPTION
It wasn't enough for me to observe "pjax:success" or "pjax:complete" events, so I just tweaked the code a bit to save the "success" function if it's passed in and then call it after the firing the pjax event. Doubt it's the best way but really needed a way to be able to add a callback. 

So essentially, now I'm able to add a callback per pjax call like so...

``` javascript
$.pjax({url: "someurl", 
 "container": "#container", 
 "success" : function(data, status, xhr, options){
    // do something here...
 });
```
