### PR TITLE
fix for handleSubmit not properly adding hidden _pjax param (ie. back button issues)

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -129,6 +129,10 @@ function handleSubmit(event, container, options) {
     target: form
   }
 
+  // serializeArray produces arrays of key/value pairs so we need to
+  // craft a special _pjax param that fits this convention
+  defaults.data.push({name: "_pjax", value: "true"})
+
   pjax($.extend({}, defaults, options))
 
   event.preventDefault()
@@ -171,7 +175,11 @@ function pjax(options) {
   // Without adding this secret parameter, some browsers will often
   // confuse the two.
   if (!options.data) options.data = {}
-  options.data._pjax = context.selector
+
+  // upstream handlers, such as handleSubmit, may set the param _pjax
+  // for us and we should respect their _pjax param since they have
+  // more context on the situation.
+  options.data._pjax = options.data._pjax || context.selector
 
   function fire(type, args) {
     var event = $.Event(type, { relatedTarget: target })

--- a/test/unit/pjax.js
+++ b/test/unit/pjax.js
@@ -229,6 +229,30 @@ if ($.support.pjax) {
     })
   })
 
+  asyncTest("sets hidden _pjax param on XHR form submission", function() {
+    var frame = this.frame
+    var iframe = this.iframe
+
+    iframe.src = "/form.html"
+
+    $(iframe).load(function(){
+      var form = frame.$("form")
+
+      frame.$('#form').on('pjax:success', function() {
+        var env = JSON.parse(frame.$("#env").text())
+        equal(env['rack.request.query_hash']['_pjax'], "true")
+        start()
+      })
+
+      form.submit(function(event){
+        frame.$.pjax.submit(event, form)
+        return false;
+      });
+
+      form.submit()
+    });
+  })
+
   asyncTest("preserves query string on GET request", function() {
     var frame = this.frame
 

--- a/test/views/form.erb
+++ b/test/views/form.erb
@@ -1,0 +1,6 @@
+<%= title 'Form' %>
+
+<form id="form" action="env.html" method="GET" data-pjax>
+  <input type="text" name="foo" value="1" />
+  <input type="text" name="bar" value="2" />
+</form>


### PR DESCRIPTION
Also see defunkt/jquery-pjax#270

The problem is that handleSubmit produces an array of key/value pairs, which is different than the other pjax submission cases. In the common case jquery.pjax adds the _pjax=true param to the query string. In the handleSubmit case this param is lost. Here I've made handleSubmit deal with the pjax key directly and the pjax common case defers to the upstream format.

At the end of the day the param gets sent down the same: &_pjax=true and everything is happy.

I think this solves the issue slightly better than the solution posted in defunkt/jquery-pjax#270 and also includes a test to illustrate the failure case.
