### PR TITLE
 Fixed choice of container on popstate

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -401,15 +401,20 @@ function onPjaxPopstate(event) {
     // page.
     if (initialPop && initialURL == state.url) return
 
-    var container = $(state.container)
+    var container, direction
+    if (pjax.state) {
+      // Since state ids always increase, we can deduce the history
+      // direction from the previous state.
+      direction = pjax.state.id < state.id ? 'forward' : 'back'
+    }
+
+    // Should use container in current state when going back
+    // as we cache its content when coming to this state
+    container = $(direction === 'back' ? pjax.state.container : state.container)
     if (container.length) {
-      var direction, contents = cacheMapping[state.id]
+      var contents = cacheMapping[state.id]
 
       if (pjax.state) {
-        // Since state ids always increase, we can deduce the history
-        // direction from the previous state.
-        direction = pjax.state.id < state.id ? 'forward' : 'back'
-
         // Cache current container before replacement and inform the
         // cache which direction the history shifted.
         cachePop(direction, pjax.state.id, container.clone().contents())


### PR DESCRIPTION
The choice of container on popstate should depend on history direction.

Consider the following scenario:
page1 --container1--> page2 --container2--> page3
1. When we go from page1 to page2, contents in container1 is cached and replaced.
1. When we go to page3, contents in container2 is cached and replaced.
Therefore:
1. When we go back to page2 (from page3), we should change the contents of container2.
2. When we go forward to page2 (from page1), we should change the contents of container1.
