### PR TITLE
Don't blur body element (IE compatibility)

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -262,7 +262,10 @@ function pjax(options) {
     }
 
     // Clear out any focused controls before inserting new page contents.
-    document.activeElement.blur()
+    if (document.activeElement && document.activeElement.node!='BODY')
+    {
+        document.activeElement.blur();
+    }
 
     if (container.title) document.title = container.title
     context.html(container.contents)


### PR DESCRIPTION
From:
http://connect.microsoft.com/IE/feedback/details/790929/document-activeelement-blur

"If you have to remove the focus from an active element using JavaScript blur()
function, make sure that the active element is not BODY. Otherwise, if your HTML
page is the only opened tab, the IE will go to the bottom of the opened windows
stack."
