### PR TITLE
prevent error in non pjax onpopstate

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -395,7 +395,7 @@ if ('state' in window.history) {
 function onPjaxPopstate(event) {
   var state = event.state
 
-  if (state && state.container) {
+  if (pjax.state && state && state.container) {
     // When coming forward from a separate history session, will get an
     // initial pop with a state we are already at. Skip reloading the current
     // page.


### PR DESCRIPTION
```
.............................................TypeError: 'undefined' is not an object (evaluating 'pjax.state.id')

  http://localhost:4567/jquery.pjax.js:406 in onPjaxPopstate
  http://localhost:4567/test/jquery-1.9.0.js:3045
  http://localhost:4567/test/jquery-1.9.0.js:2721
Timeout
```
- this is throwing exception and causing tests to fall (although it doesn't break the functionality)
