### PR TITLE
avoid lossing body when parsing html

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -600,6 +600,7 @@ function findAll(elems, selector) {
 }
 
 function parseHTML(html) {
+  html = html.replace(/^<(head|body)/i, '<div').replace(/<\/(head|body)>$/i, '</div>')
   return $.parseHTML(html, document, true)
 }
 

--- a/test/unit/pjax.js
+++ b/test/unit/pjax.js
@@ -314,7 +314,7 @@ if ($.support.pjax) {
 
     frame.$('body').on('pjax:success', function(event, data) {
       equal(typeof data, 'string')
-      equal(frame.$("body > p").html().trim(), "Hello!")
+      equal(frame.$("body > #main > p").html().trim(), "Hello!")
       equal(frame.document.title, "Hello")
       start()
     })


### PR DESCRIPTION
- as http://api.jquery.com/jQuery/#jQuery2 stats, the parsing process
  may strip `body` element, and return children of `body` instead of
  body. And this happens in most modern browsers (Chrome / Firefox latest releases).

```
When passing in complex HTML, some browsers may not generate a DOM that
exactly replicates the HTML source provided. As mentioned, jQuery uses
the browser"s .innerHTML property to parse the passed HTML and insert
it into the current document. During this process, some browsers filter
out certain elements such as  <html>,  <title>, or  <head> elements. As
a result, the elements inserted may not be representative of the
original string passed.
```
- Also fixed the corresponding unit test.
