### PR TITLE
bug if form input "name" is same as form attribute

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -117,15 +117,16 @@ function handleSubmit(event, container, options) {
   options = optionsFor(container, options)
 
   var form = event.currentTarget
+  var $form = $(form)
 
   if (form.tagName.toUpperCase() !== 'FORM')
     throw "$.pjax.submit requires a form element"
 
   var defaults = {
-    type: form.method.toUpperCase(),
-    url: form.action,
-    data: $(form).serializeArray(),
-    container: $(form).attr('data-pjax'),
+    type: $form.attr('method').toUpperCase(),
+    url: $form.attr('action'),
+    data: $form.serializeArray(),
+    container: $form.attr('data-pjax'),
     target: form
   }
 


### PR DESCRIPTION
If you have a form input whose "name" attribute is the same as one of the properties being created in the defaults object then the input object is assigned instead of the form attribute.

Example:

```
<form action="/foo/bar">
   <input name="action">
</form>
```

defaults.url = [object%20HTMLInputElement]
