### PR TITLE
Small clarification to the demo page text

### DIFF
--- a/app/views/index.erb
+++ b/app/views/index.erb
@@ -11,7 +11,7 @@
 </p>
 
 <p>
-  Check the box to toggle pjax.
+  Check the box to toggle pjax. Compare the experience of clicking around the three links listed above when pjax is enabled, versus when it's not.
 </p>
 
 <p>


### PR DESCRIPTION
It took me a while to figure out that the visible difference between pjax-on and pjax-off comes by comparing the experience of clicking around the three supplied links, in the two modes. (Until then I thought that maybe the clock was going to prove a point by updating by itself, or something.)

So, I added a few clarifying words to the index page's text.
