### PR TITLE
Minifiers should retain copyright notice

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -1,6 +1,8 @@
-// jquery.pjax.js
-// copyright chris wanstrath
-// https://github.com/defunkt/jquery-pjax
+/*!
+ * jquery.pjax.js
+ * copyright chris wanstrath
+ * https://github.com/defunkt/jquery-pjax
+ */
 
 (function($){
 


### PR DESCRIPTION
C-style block comments that start with `/*!` remain untouched by minifiers such as YUIMin, JSMin, etc.

jQuery itself already does this (see jquery/jquery@192d6cd4a30bef497f72b1ca9b62fd8b90ade806).
