### PR TITLE
Add support for file input fields

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -129,7 +129,7 @@ function handleSubmit(event, container, options) {
     target: form
   }
 
-  if (defaults.type === 'POST' && window.FormData !== undefined) {
+  if (defaults.type !== 'GET' && window.FormData !== undefined) {
     defaults.data = new FormData(form);
     defaults.processData = false;
     defaults.contentType = false;


### PR DESCRIPTION
Uses `FormData`, if available, else it falls back to the current way of handling fields. I also added a check to see if there were file fields present (when falling back to old way of handling) and exit if so (to let the browser handle them properly).

Fixes #225
