### PR TITLE
Send version request header

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -189,7 +189,14 @@ function pjax(options) {
       settings.timeout = 0
     }
 
+    // If $.pjax.defaults.version is a function, invoke it first.
+    // Otherwise it can be a static string.
+    var currentVersion = (typeof $.pjax.defaults.version === 'function') ?
+      $.pjax.defaults.version() :
+      $.pjax.defaults.version
+
     xhr.setRequestHeader('X-PJAX', 'true')
+    xhr.setRequestHeader('X-PJAX-Version', currentVersion)
     xhr.setRequestHeader('X-PJAX-Container', context.selector)
 
     if (!fire('pjax:beforeSend', [xhr, settings]))


### PR DESCRIPTION
In order to avoid wasting server resources, I'd like to be able to check the `version` already registered for PJAX before processing anything, in order to end the request early, sending the new version via a response header.

This PR fixes the issue, but does result in a bit of duplication (`currentVersion` code is copied from `options.success()`).
