### PR TITLE
Test for <html in $body instead of data

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -656,7 +656,7 @@ function extractContainer(data, xhr, options) {
         obj.title = $fragment.attr('title') || $fragment.data('title')
     }
 
-  } else if (!/<html/i.test(data)) {
+  } else if (!/<html/i.test($body)) {
     obj.contents = $body
   }
 


### PR DESCRIPTION
When the response includes `<html`, it is split into `$head` (`<head>`) and `$body` (`<body>`), but `$body` is currently ignored if `data` includes `<html`.
