### PR TITLE
IE fix for blurring of active element

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -263,7 +263,9 @@ function pjax(options) {
     }
 
     // Clear out any focused controls before inserting new page contents.
-    document.activeElement.blur()
+    try {
+      document.activeElement.blur()
+    } catch (e) { }
 
     if (container.title) document.title = container.title
     context.html(container.contents)


### PR DESCRIPTION
In IE, activeElement might be null, BODY element, or SVG element. In all such cases, `blur()` will throw an exception. This swallows the exception and moves on.

Handles #316 #370 as well

/cc @josh @nuclearsandwich
