### PR TITLE
Add an option to configure automatic input blurring

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -147,6 +147,8 @@ function handleSubmit(event, container, options) {
 //             $(container).html(xhr.responseBody)
 //      push - Whether to pushState the URL. Defaults to true (of course).
 //   replace - Want to use replaceState instead? That's cool.
+// keepFocus - Whether to keep focus of active elements. pjax removes
+//             focus from the active element by default
 //
 // Use it just like $.ajax:
 //
@@ -262,10 +264,12 @@ function pjax(options) {
       window.history.replaceState(pjax.state, container.title, container.url)
     }
 
-    // Clear out any focused controls before inserting new page contents.
-    try {
-      document.activeElement.blur()
-    } catch (e) { }
+    if (!options.keepFocus) {
+      // Clear out any focused controls before inserting new page contents.
+      try {
+        document.activeElement.blur()
+      } catch (e) { }
+    }
 
     if (container.title) document.title = container.title
     context.html(container.contents)

--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -800,7 +800,8 @@ function enable() {
     dataType: 'html',
     scrollTo: 0,
     maxCacheLength: 20,
-    version: findVersion
+    version: findVersion,
+    keepFocus: false
   }
   $(window).on('popstate.pjax', onPjaxPopstate)
 }

--- a/test/unit/pjax.js
+++ b/test/unit/pjax.js
@@ -1083,4 +1083,31 @@ if ($.support.pjax) {
       container: "#main"
     })
   })
+
+  asyncTest("keeps focus on active element", function () {
+    var frame = this.frame
+
+    frame.$("#main").one("pjax:complete", function() {
+      var input = frame.$("input")
+      ok(!input.is(":focus"))
+      input.focus()
+      ok(input.is(":focus"))
+
+      frame.$("#main").one("pjax:complete", function() {
+        ok(input.is(":focus"), "Failed to keep focus on the element")
+        start()
+      })
+
+      frame.$.pjax({
+        url: "hello.html",
+        container: "#results",
+        keepFocus: true
+      })
+    })
+
+    frame.$.pjax({
+      url: "inputs.html",
+      container: "#main"
+    })
+  })
 }

--- a/test/unit/pjax.js
+++ b/test/unit/pjax.js
@@ -1057,4 +1057,30 @@ if ($.support.pjax) {
       })
     })
   })
+
+  asyncTest("doesn't keep focus on active element", function () {
+    var frame = this.frame
+
+    frame.$("#main").one("pjax:complete", function() {
+      var input = frame.$("input")
+      ok(!input.is(":focus"))
+      input.focus()
+      ok(input.is(":focus"))
+
+      frame.$("#main").one("pjax:complete", function() {
+        ok(!input.is(":focus"))
+        start()
+      })
+
+      frame.$.pjax({
+        url: "hello.html",
+        container: "#results"
+      })
+    })
+
+    frame.$.pjax({
+      url: "inputs.html",
+      container: "#main"
+    })
+  })
 }

--- a/test/views/inputs.erb
+++ b/test/views/inputs.erb
@@ -1,0 +1,3 @@
+<input type="text" id="focus-input">
+<div id="results">
+</div>

--- a/test/views/inputs.erb
+++ b/test/views/inputs.erb
@@ -1,3 +1,3 @@
-<input type="text" id="focus-input">
+<input type="text">
 <div id="results">
 </div>


### PR DESCRIPTION
This will fix issue #377 if merged in. This pull request also adds test case for the default behavior of blurring the active element always.