### PR TITLE
Ignore events with prevented defaults

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -82,6 +82,10 @@ function handleClick(event, container, options) {
   if (link.href === location.href + '#')
     return
 
+  // Ignore event with default prevented
+  if (event.isDefaultPrevented())
+    return
+
   var defaults = {
     url: link.href,
     container: $(link).attr('data-pjax'),

--- a/test/unit/fn_pjax.js
+++ b/test/unit/fn_pjax.js
@@ -191,6 +191,25 @@ if ($.support.pjax) {
     start()
   })
 
+  asyncTest("ignores event with prevented default", function() {
+    var frame = this.frame
+    var eventIgnored = true
+
+    frame.$("#main").pjax("a").on("pjax:click", function() {
+      eventIgnored = false
+    })
+    frame.$("a[href='/dinosaurs.html']").on("click", function(event) {
+      event.preventDefault()
+      setTimeout(function() {
+        ok(eventIgnored, "Event with prevented default ignored")
+        start()
+      }, 10)
+    })
+
+    frame.$("a[href='/dinosaurs.html']").click()
+  })
+
+
   asyncTest("scrolls to anchor after load", function() {
     var frame = this.frame
 


### PR DESCRIPTION
If a click event has a prevented default (say because some other JS has already handled the event doing something else) then `pjax` should ignore the event.

It seems obvious to me, but if further justification is needed, not ignoring the event behaves differently than the fallback behavior (non pushState browsers or if calling `$.pjax.disable()`).
