### PR TITLE
Change name in bower.json from "pjax" to "jquery-pjax"

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "pjax",
+  "name": "jquery-pjax",
   "version": "1.8.2",
   "main": "./jquery.pjax.js",
   "dependencies": {


### PR DESCRIPTION
The name of the package should match the name it is registered as in
Bower. Since this package is registered as "jquery-pjax", the name
should be that. This is also consistent with the name of the repo.
