### PR TITLE
Added pjax CDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,5 +419,4 @@ $ open http://localhost:4567/
 ```
 
 [compat]: http://caniuse.com/#search=pushstate
-[cdnjs]: http://cdnjs.com/libraries/jquery.pjax
 [gist]: https://gist.github.com/

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ If you wish to use a CDN, please take a look at the ones below.
 #### jsdelivr.com
 
 ```
-<script src="//cdn.jsdelivr.net/jquery.pjax/1.8.2/jquery.pjax.min.js"></script>
+<script src="//cdn.jsdelivr.net/jquery.pjax/1.8/jquery.pjax.min.js"></script>
 ```
 
 ## Dependencies

--- a/README.md
+++ b/README.md
@@ -104,7 +104,21 @@ pjax can be downloaded directly into your app's public directory - just be sure 
 curl -O https://raw.github.com/defunkt/jquery-pjax/master/jquery.pjax.js
 ```
 
-**WARNING** Do not hotlink the raw script url. GitHub is not a CDN, use a [CDN][cdnjs] instead.
+**WARNING** Do not hotlink the raw script url. GitHub is not a CDN, use one of the *real* CDNs below.
+
+### cdn
+If you wish to use a CDN, please take a look at the ones below.
+
+#### cdnjs.com
+```
+<script src="//cdnjs.cloudflare.com/ajax/libs/jquery.pjax/1.8.2/jquery.pjax.min.js"></script>
+```
+
+#### jsdelivr.com
+
+```
+<script src="//cdn.jsdelivr.net/jquery.pjax/1.8.2/jquery.pjax.min.js"></script>
+```
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ pjax can be downloaded directly into your app's public directory - just be sure 
 curl -O https://raw.github.com/defunkt/jquery-pjax/master/jquery.pjax.js
 ```
 
-**WARNING** Do not hotlink the raw script url. GitHub is not a CDN.
+**WARNING** Do not hotlink the raw script url. GitHub is not a CDN, use a [CDN][cdnjs] instead.
 
 ## Dependencies
 
@@ -405,4 +405,5 @@ $ open http://localhost:4567/
 ```
 
 [compat]: http://caniuse.com/#search=pushstate
+[cdnjs]: http://cdnjs.com/libraries/jquery.pjax
 [gist]: https://gist.github.com/


### PR DESCRIPTION
Since cdnjs.com offers CDN for pjax, we might as well just add it.