### PR TITLE
Abort pending XHR in popstate handler

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -331,11 +331,7 @@ function pjax(options) {
   }
 
   // Cancel the current request if we're already pjaxing
-  var xhr = pjax.xhr
-  if ( xhr && xhr.readyState < 4) {
-    xhr.onreadystatechange = $.noop
-    xhr.abort()
-  }
+  abortXHR(pjax.xhr)
 
   pjax.options = options
   var xhr = pjax.xhr = $.ajax(options)
@@ -402,6 +398,12 @@ if ('state' in window.history) {
 // You probably shouldn't use pjax on pages with other pushState
 // stuff yet.
 function onPjaxPopstate(event) {
+
+  // Hitting back or forward should override any pending PJAX request.
+  if (!initialPop) {
+    abortXHR(pjax.xhr)
+  }
+
   var state = event.state
 
   if (state && state.container) {
@@ -502,6 +504,15 @@ function fallbackPjax(options) {
 
   $(document.body).append(form)
   form.submit()
+}
+
+// Internal: Abort an XmlHttpRequest if it hasn't been completed,
+// also removing its event handlers.
+function abortXHR(xhr) {
+  if ( xhr && xhr.readyState < 4) {
+    xhr.onreadystatechange = $.noop
+    xhr.abort()
+  }
 }
 
 // Internal: Generate unique id for state object.

--- a/test/unit/pjax.js
+++ b/test/unit/pjax.js
@@ -749,6 +749,49 @@ if ($.support.pjax) {
     }, 0)
   }
 
+  asyncTest("clicking back while loading cancels XHR", function() {
+    var frame = this.frame
+
+    frame.$("#main").one('pjax:complete', function() {
+
+      frame.$("#main").one('pjax:send', function() {
+
+        // Check that our request is aborted (need to check
+        // how robust this is across browsers)
+        frame.$("#main").one('pjax:complete', function(e, xhr, textStatus) {
+          equal(xhr.status, 0)
+          equal(textStatus, 'abort')
+        })
+
+        // Make sure the URL and content remain the same after the
+        // XHR would have arrived (delay on timeout.html is 1s)
+        setTimeout(function() {
+          var afterBackLocation = frame.location.pathname
+          var afterBackTitle = frame.document.title
+
+          setTimeout(function() {
+            equal(frame.location.pathname, afterBackLocation)
+            equal(frame.document.title, afterBackTitle)
+            start()
+          }, 1000)
+        }, 500)
+
+        frame.history.back()
+
+      })
+
+      frame.$.pjax({
+        url: "timeout.html",
+        container: "#main"
+      })
+    })
+
+    frame.$.pjax({
+      url: "hello.html",
+      container: "#main"
+    })
+  })
+
   asyncTest("popstate going back to page", function() {
     var frame = this.frame
 

--- a/test/unit/pjax.js
+++ b/test/unit/pjax.js
@@ -752,42 +752,39 @@ if ($.support.pjax) {
   asyncTest("clicking back while loading cancels XHR", function() {
     var frame = this.frame
 
-    frame.$("#main").one('pjax:complete', function() {
+    frame.$('#main').on('pjax:timeout', function(event) {
+      event.preventDefault()
+    })
 
-      frame.$("#main").one('pjax:send', function() {
+    frame.$("#main").one('pjax:send', function() {
 
-        // Check that our request is aborted (need to check
-        // how robust this is across browsers)
-        frame.$("#main").one('pjax:complete', function(e, xhr, textStatus) {
-          equal(xhr.status, 0)
-          equal(textStatus, 'abort')
-        })
+      // Check that our request is aborted (need to check
+      // how robust this is across browsers)
+      frame.$("#main").one('pjax:complete', function(e, xhr, textStatus) {
+        equal(xhr.status, 0)
+        equal(textStatus, 'abort')
+      })
 
-        // Make sure the URL and content remain the same after the
-        // XHR would have arrived (delay on timeout.html is 1s)
-        setTimeout(function() {
-          var afterBackLocation = frame.location.pathname
-          var afterBackTitle = frame.document.title
-
-          setTimeout(function() {
-            equal(frame.location.pathname, afterBackLocation)
-            equal(frame.document.title, afterBackTitle)
-            start()
-          }, 1000)
-        }, 500)
-
+      setTimeout(function() {
         frame.history.back()
+      }, 250)
 
-      })
+      // Make sure the URL and content remain the same after the
+      // XHR would have arrived (delay on timeout.html is 1s)
+      setTimeout(function() {
+        var afterBackLocation = frame.location.pathname
+        var afterBackTitle = frame.document.title
 
-      frame.$.pjax({
-        url: "timeout.html",
-        container: "#main"
-      })
+        setTimeout(function() {
+          equal(frame.location.pathname, afterBackLocation)
+          equal(frame.document.title, afterBackTitle)
+          start()
+        }, 1000)
+      }, 500)
     })
 
     frame.$.pjax({
-      url: "hello.html",
+      url: "timeout.html",
       container: "#main"
     })
   })


### PR DESCRIPTION
This fixes the bug where, if the user clicks back while a PJAX request is loading, the originally requested page is displayed anyway once the XHR response arrives.