### PR TITLE
Only set pjax.state if pushing or replacing

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -252,7 +252,6 @@ function pjax(options) {
       locationReplace(container.url)
       return
     }
-
     if (options.push || options.replace) {
       pjax.state = {
         id: options.id || uniqueId(),
@@ -438,6 +437,7 @@ function onPjaxPopstate(event) {
         url: state.url,
         container: container,
         push: false,
+        replace: true,
         fragment: state.fragment,
         timeout: state.timeout,
         scrollTo: false


### PR DESCRIPTION
PJAX with both both options.push and options.replace set to false can be used to simply replace chunks of page content, without touching your navigation history.

This use case is undocumented and not robust, but this tiny change ensures that PJAX back/forward behaviour stays correct even if PJAX is used in this "stateless" way elsewhere on the page.
