### PR TITLE
Run scripts when going back in history

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -450,6 +450,12 @@ function onPjaxPopstate(event) {
         if (state.title) document.title = state.title
         container.trigger('pjax:beforeReplace', [contents, options])
         container.html(contents)
+
+        scripts = findAll(contents, 'script')
+        scripts.each(function() {
+          eval(this.innerText)
+        })
+
         pjax.state = state
 
         container.trigger('pjax:end', [null, options])


### PR DESCRIPTION
When using the browser back button I found that scripts inside my previous pjax container wouldn't run. I.e. if i have stuff like

```
<script type="text/javascript">
  ...
</script>
```

Then suppose I load it into my pjax container, follow a link and load another page into my pjax container and finally use the browser back button to return. What ends up happening is that on returning the script will not run. For me the expected behaviour would be that the script would run on returning or that the state of the page is as it was after the script had run on the first load.

I therefore made pjax eval scripts in previous containers and this made it to work for my use case. Not sure it's generalized enough to make it back into core but I figured I'd open a pr incase others have the same issues and perhaps the fix is good enough for you guys :)
