### PR TITLE
Include contents as argument in popstate event

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ container, not the link that was clicked.
 <tr>
   <td><code>pjax:popstate</code></td>
   <td></td>
-  <td></td>
+  <td><code>contents</code></td>
   <td>event <code>direction</code> property: &quot;back&quot;/&quot;forward&quot;</td>
 </tr>
 <tr>

--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -432,7 +432,7 @@ function onPjaxPopstate(event) {
         state: state,
         direction: direction
       })
-      container.trigger(popstateEvent)
+      container.trigger(popstateEvent, contents)
 
       var options = {
         id: state.id,

--- a/test/unit/pjax.js
+++ b/test/unit/pjax.js
@@ -837,10 +837,11 @@ if ($.support.pjax) {
       ok(frame.history.length > 1)
       goBack(frame, function() {})
     })
-    frame.$('#main').on('pjax:popstate', function(event) {
+    frame.$('#main').on('pjax:popstate', function(event, contents) {
       equal(frame.location.pathname, "/home.html")
       equal(event.state.container, '#main')
       equal(event.direction, 'back')
+      ok(contents)
       start()
     })
 


### PR DESCRIPTION
At Causes, we are using pjax in conjunction with Reactjs. As we have
currently implemented things, when using the back and forward buttons
(popstate), the following warning is logged:

> React attempted to use reuse markup in a container but the checksum
> was invalid. This generally means that you are using server rendering
> and the markup generated on the server was not what the client was
> expecting. React injected new markup to compensate which works but you
> have lost many of the benefits of server rendering. Instead, figure
> out why the markup being generated is different on the client or
> server.

To prevent this message from happening, we need a way to clean out the
markup that was generated by React components before putting them back
on the page. It seems like an event handler that listens to the
pjax:popstate event is a reasonable place to do this, but the page's
contents are not sent along with that event.

This commit includes the contents that will end up on the page when
popping state in the pjax:popstate event that is triggered. This will
enable us to clean out the bits that are not desired before they hit the
page.
