### PR TITLE
Added semi-colon line terminators to javascript

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -28,13 +28,13 @@
 //
 // Returns the jQuery object
 function fnPjax(selector, container, options) {
-  var context = this
+  var context = this;
   return this.on('click.pjax', selector, function(event) {
-    var opts = $.extend({}, optionsFor(container, options))
+    var opts = $.extend({}, optionsFor(container, options));
     if (!opts.container)
-      opts.container = $(this).attr('data-pjax') || context
-    handleClick(event, opts)
-  })
+      opts.container = $(this).attr('data-pjax') || context;
+    handleClick(event, opts);
+  });
 }
 
 // Public: pjax on click handler
@@ -57,49 +57,49 @@ function fnPjax(selector, container, options) {
 //
 // Returns nothing.
 function handleClick(event, container, options) {
-  options = optionsFor(container, options)
+  options = optionsFor(container, options);
 
-  var link = event.currentTarget
+  var link = event.currentTarget;
 
   if (link.tagName.toUpperCase() !== 'A')
-    throw "$.fn.pjax or $.pjax.click requires an anchor element"
+    throw "$.fn.pjax or $.pjax.click requires an anchor element"; 
 
   // Middle click, cmd click, and ctrl click should open
   // links in a new tab as normal.
   if ( event.which > 1 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey )
-    return
+    return; 
 
   // Ignore cross origin links
   if ( location.protocol !== link.protocol || location.hostname !== link.hostname )
-    return
+    return; 
 
   // Ignore anchors on the same page
   if (link.hash && link.href.replace(link.hash, '') ===
        location.href.replace(location.hash, ''))
-    return
+   return; 
 
   // Ignore empty anchor "foo.html#"
   if (link.href === location.href + '#')
-    return
+    return; 
 
   // Ignore event with default prevented
   if (event.isDefaultPrevented())
-    return
+    return;
 
   var defaults = {
     url: link.href,
     container: $(link).attr('data-pjax'),
     target: link
-  }
+  };
 
-  var opts = $.extend({}, defaults, options)
-  var clickEvent = $.Event('pjax:click')
-  $(link).trigger(clickEvent, [opts])
+  var opts = $.extend({}, defaults, options);
+  var clickEvent = $.Event('pjax:click');
+  $(link).trigger(clickEvent, [opts]);
 
   if (!clickEvent.isDefaultPrevented()) {
-    pjax(opts)
-    event.preventDefault()
-    $(link).trigger('pjax:clicked', [opts])
+    pjax(opts);
+    event.preventDefault();
+    $(link).trigger('pjax:clicked', [opts]);
   }
 }
 
@@ -119,12 +119,12 @@ function handleClick(event, container, options) {
 //
 // Returns nothing.
 function handleSubmit(event, container, options) {
-  options = optionsFor(container, options)
+  options = optionsFor(container, options);
 
-  var form = event.currentTarget
+  var form = event.currentTarget;
 
   if (form.tagName.toUpperCase() !== 'FORM')
-    throw "$.pjax.submit requires a form element"
+    throw "$.pjax.submit requires a form element";
 
   var defaults = {
     type: form.method.toUpperCase(),
@@ -132,11 +132,11 @@ function handleSubmit(event, container, options) {
     data: $(form).serializeArray(),
     container: $(form).attr('data-pjax'),
     target: form
-  }
+  };
 
-  pjax($.extend({}, defaults, options))
+  pjax($.extend({}, defaults, options));
 
-  event.preventDefault()
+  event.preventDefault();
 }
 
 // Loads a URL with ajax, puts the response body inside a container,
@@ -159,98 +159,98 @@ function handleSubmit(event, container, options) {
 //
 // Returns whatever $.ajax returns.
 function pjax(options) {
-  options = $.extend(true, {}, $.ajaxSettings, pjax.defaults, options)
+  options = $.extend(true, {}, $.ajaxSettings, pjax.defaults, options);
 
   if ($.isFunction(options.url)) {
-    options.url = options.url()
+    options.url = options.url();
   }
 
-  var target = options.target
+  var target = options.target;
 
-  var hash = parseURL(options.url).hash
+  var hash = parseURL(options.url).hash;
 
-  var context = options.context = findContainerFor(options.container)
+  var context = options.context = findContainerFor(options.container); 
 
   // We want the browser to maintain two separate internal caches: one
   // for pjax'd partial page loads and one for normal page loads.
   // Without adding this secret parameter, some browsers will often
   // confuse the two.
-  if (!options.data) options.data = {}
-  options.data._pjax = context.selector
+  if (!options.data) options.data = {};
+  options.data._pjax = context.selector;
 
   function fire(type, args) {
-    var event = $.Event(type, { relatedTarget: target })
-    context.trigger(event, args)
-    return !event.isDefaultPrevented()
+    var event = $.Event(type, { relatedTarget: target });
+    context.trigger(event, args);
+    return !event.isDefaultPrevented();
   }
 
-  var timeoutTimer
+  var timeoutTimer;
 
   options.beforeSend = function(xhr, settings) {
     // No timeout for non-GET requests
     // Its not safe to request the resource again with a fallback method.
     if (settings.type !== 'GET') {
-      settings.timeout = 0
+      settings.timeout = 0;
     }
 
-    xhr.setRequestHeader('X-PJAX', 'true')
-    xhr.setRequestHeader('X-PJAX-Container', context.selector)
+    xhr.setRequestHeader('X-PJAX', 'true');
+    xhr.setRequestHeader('X-PJAX-Container', context.selector);
 
     if (!fire('pjax:beforeSend', [xhr, settings]))
-      return false
+      return false;
 
     if (settings.timeout > 0) {
       timeoutTimer = setTimeout(function() {
         if (fire('pjax:timeout', [xhr, options]))
-          xhr.abort('timeout')
-      }, settings.timeout)
+          xhr.abort('timeout');
+      }, settings.timeout); 
 
       // Clear timeout setting so jquerys internal timeout isn't invoked
-      settings.timeout = 0
+      settings.timeout = 0;
     }
 
-    options.requestUrl = parseURL(settings.url).href
-  }
+    options.requestUrl = parseURL(settings.url).href;
+  };
 
   options.complete = function(xhr, textStatus) {
     if (timeoutTimer)
-      clearTimeout(timeoutTimer)
+      clearTimeout(timeoutTimer);
 
-    fire('pjax:complete', [xhr, textStatus, options])
+    fire('pjax:complete', [xhr, textStatus, options]);
 
-    fire('pjax:end', [xhr, options])
-  }
+    fire('pjax:end', [xhr, options]);
+  };
 
   options.error = function(xhr, textStatus, errorThrown) {
-    var container = extractContainer("", xhr, options)
+    var container = extractContainer("", xhr, options);
 
-    var allowed = fire('pjax:error', [xhr, textStatus, errorThrown, options])
+    var allowed = fire('pjax:error', [xhr, textStatus, errorThrown, options]);
     if (options.type == 'GET' && textStatus !== 'abort' && allowed) {
-      locationReplace(container.url)
+      locationReplace(container.url);
     }
-  }
+  };
 
   options.success = function(data, status, xhr) {
     // If $.pjax.defaults.version is a function, invoke it first.
     // Otherwise it can be a static string.
     var currentVersion = (typeof $.pjax.defaults.version === 'function') ?
       $.pjax.defaults.version() :
-      $.pjax.defaults.version
+      $.pjax.defaults.version;
 
-    var latestVersion = xhr.getResponseHeader('X-PJAX-Version')
+    var latestVersion = xhr.getResponseHeader('X-PJAX-Version');
 
-    var container = extractContainer(data, xhr, options)
+    var container = extractContainer(data, xhr, options); 
 
     // If there is a layout version mismatch, hard load the new url
     if (currentVersion && latestVersion && currentVersion !== latestVersion) {
-      locationReplace(container.url)
-      return
+      locationReplace(container.url);
+      return;
     }
 
     // If the new response is missing a body, hard load the page
     if (!container.contents) {
-      locationReplace(container.url)
-      return
+      locationReplace(container.url);
+      return;
     }
 
     pjax.state = {
@@ -260,37 +260,37 @@ function pjax(options) {
       container: context.selector,
       fragment: options.fragment,
       timeout: options.timeout
-    }
+    };
 
     if (options.push || options.replace) {
-      window.history.replaceState(pjax.state, container.title, container.url)
+      window.history.replaceState(pjax.state, container.title, container.url);
     }
 
     // Clear out any focused controls before inserting new page contents.
     try {
-      document.activeElement.blur()
+      document.activeElement.blur();
     } catch (e) { }
 
-    if (container.title) document.title = container.title
+    if (container.title) document.title = container.title;
 
-    fire('pjax:beforeReplace', [container.contents, options])
-    context.html(container.contents)
+    fire('pjax:beforeReplace', [container.contents, options]);
+    context.html(container.contents); 
 
     // FF bug: Won't autofocus fields that are inserted via JS.
     // This behavior is incorrect. So if theres no current focus, autofocus
     // the last field.
     //
     // http://www.w3.org/html/wg/drafts/html/master/forms.html
-    var autofocusEl = context.find('input[autofocus], textarea[autofocus]').last()[0]
+    var autofocusEl = context.find('input[autofocus], textarea[autofocus]').last()[0];
     if (autofocusEl && document.activeElement !== autofocusEl) {
       autofocusEl.focus();
     }
 
-    executeScriptTags(container.scripts)
+    executeScriptTags(container.scripts); 
 
     // Scroll to top by default
     if (typeof options.scrollTo === 'number')
-      $(window).scrollTop(options.scrollTo)
+      $(window).scrollTop(options.scrollTo); 
 
     // If the URL has a hash in it, make sure the browser
     // knows to navigate to the hash.
@@ -300,18 +300,18 @@ function pjax(options) {
       // by hand.
       //
       //   window.location.hash = hash
-      var url = parseURL(container.url)
-      url.hash = hash
+      var url = parseURL(container.url);
+      url.hash = hash;
 
-      pjax.state.url = url.href
-      window.history.replaceState(pjax.state, container.title, url.href)
+      pjax.state.url = url.href;
+      window.history.replaceState(pjax.state, container.title, url.href);
 
-      var target = $(url.hash)
-      if (target.length) $(window).scrollTop(target.offset().top)
+      var target = $(url.hash);
+      if (target.length) $(window).scrollTop(target.offset().top);
     }
 
-    fire('pjax:success', [data, status, xhr, options])
-  }
+    fire('pjax:success', [data, status, xhr, options]);
+  }; 
 
 
   // Initialize pjax.state for the initial page load. Assume we're
@@ -326,33 +326,33 @@ function pjax(options) {
       container: context.selector,
       fragment: options.fragment,
       timeout: options.timeout
-    }
-    window.history.replaceState(pjax.state, document.title)
+    };
+    window.history.replaceState(pjax.state, document.title);
   }
 
   // Cancel the current request if we're already pjaxing
-  var xhr = pjax.xhr
+  var xhr = pjax.xhr;
   if ( xhr && xhr.readyState < 4) {
-    xhr.onreadystatechange = $.noop
-    xhr.abort()
+    xhr.onreadystatechange = $.noop;
+    xhr.abort();
   }
 
-  pjax.options = options
-  var xhr = pjax.xhr = $.ajax(options)
+  pjax.options = options;
+  var xhr = pjax.xhr = $.ajax(options);
 
   if (xhr.readyState > 0) {
     if (options.push && !options.replace) {
       // Cache current container element before replacing it
-      cachePush(pjax.state.id, context.clone().contents())
+      cachePush(pjax.state.id, context.clone().contents());
 
-      window.history.pushState(null, "", stripPjaxParam(options.requestUrl))
+      window.history.pushState(null, "", stripPjaxParam(options.requestUrl));
     }
 
-    fire('pjax:start', [xhr, options])
-    fire('pjax:send', [xhr, options])
+    fire('pjax:start', [xhr, options]);
+    fire('pjax:send', [xhr, options]);
   }
 
-  return pjax.xhr
+  return pjax.xhr;
 }
 
 // Public: Reload current page with pjax.
@@ -364,9 +364,9 @@ function pjaxReload(container, options) {
     push: false,
     replace: true,
     scrollTo: false
-  }
+  };
 
-  return pjax($.extend(defaults, optionsFor(container, options)))
+  return pjax($.extend(defaults, optionsFor(container, options)));
 }
 
 // Internal: Hard replace current state with url.
@@ -376,25 +376,25 @@ function pjaxReload(container, options) {
 //
 // Returns nothing.
 function locationReplace(url) {
-  window.history.replaceState(null, "", "#")
-  window.location.replace(url)
+  window.history.replaceState(null, "", "#");
+  window.location.replace(url);
 }
 
 
-var initialPop = true
-var initialURL = window.location.href
-var initialState = window.history.state
+var initialPop = true;
+  var initialURL = window.location.href;
+  var initialState = window.history.state; 
 
 // Initialize $.pjax.state if possible
 // Happens when reloading a page and coming forward from a different
 // session history.
 if (initialState && initialState.container) {
-  pjax.state = initialState
+  pjax.state = initialState;
 }
 
 // Non-webkit browsers don't fire an initial popstate event
 if ('state' in window.history) {
-  initialPop = false
+  initialPop = false;
 }
 
 // popstate handler takes care of the back and forward buttons
@@ -402,37 +402,37 @@ if ('state' in window.history) {
 // You probably shouldn't use pjax on pages with other pushState
 // stuff yet.
 function onPjaxPopstate(event) {
-  var state = event.state
+  var state = event.state;
 
   if (state && state.container) {
     // When coming forward from a separate history session, will get an
     // initial pop with a state we are already at. Skip reloading the current
     // page.
-    if (initialPop && initialURL == state.url) return
+    if (initialPop && initialURL == state.url) return; 
 
     // If popping back to the same state, just skip.
     // Could be clicking back from hashchange rather than a pushState.
-    if (pjax.state && pjax.state.id === state.id) return
+    if (pjax.state && pjax.state.id === state.id) return;
 
-    var container = $(state.container)
+    var container = $(state.container);
     if (container.length) {
-      var direction, contents = cacheMapping[state.id]
+      var direction, contents = cacheMapping[state.id];
 
       if (pjax.state) {
         // Since state ids always increase, we can deduce the history
         // direction from the previous state.
-        direction = pjax.state.id < state.id ? 'forward' : 'back'
+        direction = pjax.state.id < state.id ? 'forward' : 'back'; 
 
         // Cache current container before replacement and inform the
         // cache which direction the history shifted.
-        cachePop(direction, pjax.state.id, container.clone().contents())
+        cachePop(direction, pjax.state.id, container.clone().contents());
       }
 
       var popstateEvent = $.Event('pjax:popstate', {
         state: state,
         direction: direction
-      })
-      container.trigger(popstateEvent)
+      });
+      container.trigger(popstateEvent);
 
       var options = {
         id: state.id,
@@ -442,29 +442,29 @@ function onPjaxPopstate(event) {
         fragment: state.fragment,
         timeout: state.timeout,
         scrollTo: false
-      }
+      };
 
       if (contents) {
-        container.trigger('pjax:start', [null, options])
+        container.trigger('pjax:start', [null, options]);
 
-        if (state.title) document.title = state.title
-        container.trigger('pjax:beforeReplace', [contents, options])
-        container.html(contents)
-        pjax.state = state
+        if (state.title) document.title = state.title;
+        container.trigger('pjax:beforeReplace', [contents, options]);
+        container.html(contents);
+        pjax.state = state;
 
-        container.trigger('pjax:end', [null, options])
+        container.trigger('pjax:end', [null, options]);
       } else {
-        pjax(options)
+        pjax(options);
       }
 
       // Force reflow/relayout before the browser tries to restore the
       // scroll position.
-      container[0].offsetHeight
+      container[0].offsetHeight;
     } else {
-      locationReplace(location.href)
+      locationReplace(location.href);
     }
   }
-  initialPop = false
+  initialPop = false;
 }
 
 // Fallback version of main pjax function for browsers that don't
@@ -473,35 +473,35 @@ function onPjaxPopstate(event) {
 // Returns nothing since it retriggers a hard form submission.
 function fallbackPjax(options) {
   var url = $.isFunction(options.url) ? options.url() : options.url,
-      method = options.type ? options.type.toUpperCase() : 'GET'
+      method = options.type ? options.type.toUpperCase() : 'GET';
 
   var form = $('<form>', {
     method: method === 'GET' ? 'GET' : 'POST',
     action: url,
     style: 'display:none'
-  })
+  });
 
   if (method !== 'GET' && method !== 'POST') {
     form.append($('<input>', {
       type: 'hidden',
       name: '_method',
       value: method.toLowerCase()
-    }))
+    }));
   }
 
-  var data = options.data
+  var data = options.data;
   if (typeof data === 'string') {
     $.each(data.split('&'), function(index, value) {
-      var pair = value.split('=')
-      form.append($('<input>', {type: 'hidden', name: pair[0], value: pair[1]}))
-    })
+      var pair = value.split('=');
+      form.append($('<input>', {type: 'hidden', name: pair[0], value: pair[1]}));
+    });
   } else if (typeof data === 'object') {
     for (key in data)
-      form.append($('<input>', {type: 'hidden', name: key, value: data[key]}))
+      form.append($('<input>', {type: 'hidden', name: key, value: data[key]}));
   }
 
-  $(document.body).append(form)
-  form.submit()
+  $(document.body).append(form);
+  form.submit();
 }
 
 // Internal: Generate unique id for state object.
@@ -511,7 +511,7 @@ function fallbackPjax(options) {
 //
 // Returns Number.
 function uniqueId() {
-  return (new Date).getTime()
+  return (new Date).getTime();
 }
 
 // Internal: Strips _pjax param from url
@@ -523,7 +523,7 @@ function stripPjaxParam(url) {
   return url
     .replace(/\?_pjax=[^&]+&?/, '?')
     .replace(/_pjax=[^&]+&?/, '')
-    .replace(/[\?&]$/, '')
+    .replace(/[\?&]$/, '');
 }
 
 // Internal: Parse URL components and returns a Locationish object.
@@ -532,9 +532,9 @@ function stripPjaxParam(url) {
 //
 // Returns HTMLAnchorElement that acts like Location.
 function parseURL(url) {
-  var a = document.createElement('a')
-  a.href = url
-  return a
+  var a = document.createElement('a');
+  a.href = url;
+  return a;
 }
 
 // Internal: Build options Object for arguments.
@@ -557,21 +557,21 @@ function parseURL(url) {
 function optionsFor(container, options) {
   // Both container and options
   if ( container && options )
-    options.container = container
+    options.container = container; 
 
   // First argument is options Object
   else if ( $.isPlainObject(container) )
-    options = container
+    options = container; 
 
   // Only container
   else
-    options = {container: container}
+    options = {container: container}; 
 
   // Find and validate container
   if (options.container)
-    options.container = findContainerFor(options.container)
+    options.container = findContainerFor(options.container);
 
-  return options
+  return options;
 }
 
 // Internal: Find container element for a variety of inputs.
@@ -583,16 +583,16 @@ function optionsFor(container, options) {
 //
 // Returns a jQuery object whose context is `document` and has a selector.
 function findContainerFor(container) {
-  container = $(container)
+  container = $(container);
 
   if ( !container.length ) {
-    throw "no pjax container for " + container.selector
+    throw "no pjax container for " + container.selector;
   } else if ( container.selector !== '' && container.context === document ) {
-    return container
+    return container;
   } else if ( container.attr('id') ) {
-    return $('#' + container.attr('id'))
+    return $('#' + container.attr('id'));
   } else {
-    throw "cant get selector for pjax container!"
+    throw "cant get selector for pjax container!";
   }
 }
 
@@ -610,7 +610,7 @@ function findAll(elems, selector) {
 }
 
 function parseHTML(html) {
-  return $.parseHTML(html, document, true)
+  return $.parseHTML(html, document, true);
 }
 
 // Internal: Extracts container and metadata from response.
@@ -625,67 +625,67 @@ function parseHTML(html) {
 //
 // Returns an Object with url, title, and contents keys.
 function extractContainer(data, xhr, options) {
-  var obj = {}
+  var obj = {}; 
 
   // Prefer X-PJAX-URL header if it was set, otherwise fallback to
   // using the original requested url.
-  obj.url = stripPjaxParam(xhr.getResponseHeader('X-PJAX-URL') || options.requestUrl)
+  obj.url = stripPjaxParam(xhr.getResponseHeader('X-PJAX-URL') || options.requestUrl); 
 
   // Attempt to parse response html into elements
   if (/<html/i.test(data)) {
-    var $head = $(parseHTML(data.match(/<head[^>]*>([\s\S.]*)<\/head>/i)[0]))
-    var $body = $(parseHTML(data.match(/<body[^>]*>([\s\S.]*)<\/body>/i)[0]))
+    var $head = $(parseHTML(data.match(/<head[^>]*>([\s\S.]*)<\/head>/i)[0]));
+    var $body = $(parseHTML(data.match(/<body[^>]*>([\s\S.]*)<\/body>/i)[0]));
   } else {
-    var $head = $body = $(parseHTML(data))
+    var $head = $body = $(parseHTML(data));
   }
 
   // If response data is empty, return fast
   if ($body.length === 0)
-    return obj
+    return obj; 
 
   // If there's a <title> tag in the header, use it as
   // the page's title.
-  obj.title = findAll($head, 'title').last().text()
+  obj.title = findAll($head, 'title').last().text();
 
   if (options.fragment) {
     // If they specified a fragment, look for it in the response
     // and pull it out.
     if (options.fragment === 'body') {
-      var $fragment = $body
+      var $fragment = $body;
     } else {
-      var $fragment = findAll($body, options.fragment).first()
+      var $fragment = findAll($body, options.fragment).first();
     }
 
     if ($fragment.length) {
-      obj.contents = $fragment.contents()
+      obj.contents = $fragment.contents(); 
 
       // If there's no title, look for data-title and title attributes
       // on the fragment
       if (!obj.title)
-        obj.title = $fragment.attr('title') || $fragment.data('title')
+        obj.title = $fragment.attr('title') || $fragment.data('title');
     }
 
   } else if (!/<html/i.test(data)) {
-    obj.contents = $body
+    obj.contents = $body;
   }
 
   // Clean up any <title> tags
   if (obj.contents) {
     // Remove any parent title elements
-    obj.contents = obj.contents.not(function() { return $(this).is('title') })
+    obj.contents = obj.contents.not(function() { return $(this).is('title'); }); 
 
     // Then scrub any titles from their descendants
-    obj.contents.find('title').remove()
+    obj.contents.find('title').remove(); 
 
     // Gather all script[src] elements
-    obj.scripts = findAll(obj.contents, 'script[src]').remove()
-    obj.contents = obj.contents.not(obj.scripts)
+    obj.scripts = findAll(obj.contents, 'script[src]').remove();
+    obj.contents = obj.contents.not(obj.scripts);
   }
 
   // Trim any whitespace off the title
-  if (obj.title) obj.title = $.trim(obj.title)
+  if (obj.title) obj.title = $.trim(obj.title);
 
-  return obj
+  return obj;
 }
 
 // Load an execute scripts using standard script request.
@@ -697,28 +697,28 @@ function extractContainer(data, xhr, options) {
 //
 // Returns nothing.
 function executeScriptTags(scripts) {
-  if (!scripts) return
+  if (!scripts) return;
 
-  var existingScripts = $('script[src]')
+  var existingScripts = $('script[src]');
 
   scripts.each(function() {
-    var src = this.src
+    var src = this.src;
     var matchedScripts = existingScripts.filter(function() {
-      return this.src === src
-    })
-    if (matchedScripts.length) return
+      return this.src === src;
+    });
+    if (matchedScripts.length) return;
 
-    var script = document.createElement('script')
-    script.type = $(this).attr('type')
-    script.src = $(this).attr('src')
-    document.head.appendChild(script)
-  })
+    var script = document.createElement('script');
+    script.type = $(this).attr('type');
+    script.src = $(this).attr('src');
+    document.head.appendChild(script);
+  });
 }
 
 // Internal: History DOM caching class.
-var cacheMapping      = {}
-var cacheForwardStack = []
-var cacheBackStack    = []
+var cacheMapping      = {};
+var cacheForwardStack = [];
+var cacheBackStack    = []; 
 
 // Push previous state id and container contents into the history
 // cache. Should be called in conjunction with `pushState` to save the
@@ -729,17 +729,17 @@ var cacheBackStack    = []
 //
 // Returns nothing.
 function cachePush(id, value) {
-  cacheMapping[id] = value
-  cacheBackStack.push(id)
+  cacheMapping[id] = value;
+  cacheBackStack.push(id); 
 
   // Remove all entires in forward history stack after pushing
   // a new page.
   while (cacheForwardStack.length)
-    delete cacheMapping[cacheForwardStack.shift()]
+    delete cacheMapping[cacheForwardStack.shift()]; 
 
   // Trim back history stack to max cache length.
   while (cacheBackStack.length > pjax.defaults.maxCacheLength)
-    delete cacheMapping[cacheBackStack.shift()]
+    delete cacheMapping[cacheBackStack.shift()];
 }
 
 // Shifts cache from directional history cache. Should be
@@ -752,20 +752,20 @@ function cachePush(id, value) {
 //
 // Returns nothing.
 function cachePop(direction, id, value) {
-  var pushStack, popStack
-  cacheMapping[id] = value
+  var pushStack, popStack;
+  cacheMapping[id] = value;
 
   if (direction === 'forward') {
-    pushStack = cacheBackStack
-    popStack  = cacheForwardStack
+    pushStack = cacheBackStack;
+    popStack  = cacheForwardStack;
   } else {
-    pushStack = cacheForwardStack
-    popStack  = cacheBackStack
+    pushStack = cacheForwardStack;
+    popStack  = cacheBackStack;
   }
 
-  pushStack.push(id)
+  pushStack.push(id);
   if (id = popStack.pop())
-    delete cacheMapping[id]
+    delete cacheMapping[id];
 }
 
 // Public: Find version identifier for the initial page load.
@@ -773,9 +773,9 @@ function cachePop(direction, id, value) {
 // Returns String version or undefined.
 function findVersion() {
   return $('meta').filter(function() {
-    var name = $(this).attr('http-equiv')
-    return name && name.toUpperCase() === 'X-PJAX-VERSION'
-  }).attr('content')
+    var name = $(this).attr('http-equiv');
+    return name && name.toUpperCase() === 'X-PJAX-VERSION';
+  }).attr('content');
 }
 
 // Install pjax functions on $.pjax to enable pushState behavior.
@@ -788,13 +788,13 @@ function findVersion() {
 //
 // Returns nothing.
 function enable() {
-  $.fn.pjax = fnPjax
-  $.pjax = pjax
-  $.pjax.enable = $.noop
-  $.pjax.disable = disable
-  $.pjax.click = handleClick
-  $.pjax.submit = handleSubmit
-  $.pjax.reload = pjaxReload
+  $.fn.pjax = fnPjax;
+  $.pjax = pjax;
+  $.pjax.enable = $.noop;
+  $.pjax.disable = disable;
+  $.pjax.click = handleClick;
+  $.pjax.submit = handleSubmit;
+  $.pjax.reload = pjaxReload;
   $.pjax.defaults = {
     timeout: 650,
     push: true,
@@ -804,8 +804,8 @@ function enable() {
     scrollTo: 0,
     maxCacheLength: 20,
     version: findVersion
-  }
-  $(window).on('popstate.pjax', onPjaxPopstate)
+  };
+  $(window).on('popstate.pjax', onPjaxPopstate);
 }
 
 // Disable pushState behavior.
@@ -820,29 +820,29 @@ function enable() {
 //
 // Returns nothing.
 function disable() {
-  $.fn.pjax = function() { return this }
-  $.pjax = fallbackPjax
-  $.pjax.enable = enable
-  $.pjax.disable = $.noop
-  $.pjax.click = $.noop
-  $.pjax.submit = $.noop
-  $.pjax.reload = function() { window.location.reload() }
+  $.fn.pjax = function() { return this; };
+  $.pjax = fallbackPjax;
+  $.pjax.enable = enable;
+  $.pjax.disable = $.noop;
+  $.pjax.click = $.noop;
+  $.pjax.submit = $.noop;
+  $.pjax.reload = function() { window.location.reload(); };
 
-  $(window).off('popstate.pjax', onPjaxPopstate)
+  $(window).off('popstate.pjax', onPjaxPopstate);
 }
 
 
 // Add the state property to jQuery's event object so we can use it in
 // $(window).bind('popstate')
 if ( $.inArray('state', $.event.props) < 0 )
-  $.event.props.push('state')
+  $.event.props.push('state'); 
 
 // Is pjax supported by this browser?
 $.support.pjax =
   window.history && window.history.pushState && window.history.replaceState &&
   // pushState isn't reliable on iOS until 5.
-  !navigator.userAgent.match(/((iPod|iPhone|iPad).+\bOS\s+[1-4]|WebApps\/.+CFNetwork)/)
+  !navigator.userAgent.match(/((iPod|iPhone|iPad).+\bOS\s+[1-4]|WebApps\/.+CFNetwork)/);
 
-$.support.pjax ? enable() : disable()
+$.support.pjax ? enable() : disable();
 
 })(jQuery);


### PR DESCRIPTION
This should prevent Visual Studio / Re# and JS Linters from complaining about missing statement line terminators.  Semi-colons added to the end of the lines with statements.
