### PR TITLE
URL preserving option

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -17,11 +17,12 @@
 // pjax specific options:
 //
 //
-// container - Where to stick the response body. Usually a String selector.
-//             $(container).html(xhr.responseBody)
-//             (default: current jquery context)
-//      push - Whether to pushState the URL. Defaults to true (of course).
-//   replace - Want to use replaceState instead? That's cool.
+//   container - Where to stick the response body. Usually a String selector.
+//               $(container).html(xhr.responseBody)
+//               (default: current jquery context)
+//        push - Whether to pushState the URL. Defaults to true (of course).
+//     replace - Want to use replaceState instead? That's cool.
+// preserveURL - Whether to preserve ULR until response comes.
 //
 // For convenience the second parameter can be either the container or
 // the options object.
@@ -147,10 +148,11 @@ function handleSubmit(event, container, options) {
 //
 // Accepts these extra keys:
 //
-// container - Where to stick the response body.
-//             $(container).html(xhr.responseBody)
-//      push - Whether to pushState the URL. Defaults to true (of course).
-//   replace - Want to use replaceState instead? That's cool.
+//   container - Where to stick the response body.
+//               $(container).html(xhr.responseBody)
+//        push - Whether to pushState the URL. Defaults to true (of course).
+//     replace - Want to use replaceState instead? That's cool.
+// preserveURL - Whether to preserve ULR until response comes.
 //
 // Use it just like $.ajax:
 //
@@ -352,7 +354,8 @@ function pjax(options) {
       // Cache current container element before replacing it
       cachePush(pjax.state.id, context.clone().contents())
 
-      window.history.pushState(null, "", stripPjaxParam(options.requestUrl))
+      var url = options.preserveURL ? undefined : stripPjaxParam(options.requestUrl)
+      window.history.pushState(null, "", url)
     }
 
     fire('pjax:start', [xhr, options])

--- a/test/unit/fn_pjax.js
+++ b/test/unit/fn_pjax.js
@@ -27,6 +27,28 @@ if ($.support.pjax) {
     frame.$("a[href='/dinosaurs.html']").click()
   })
 
+  asyncTest("pushes new url right after sending request", function() {
+    var frame = this.frame
+
+    frame.$("#main").pjax("a").on("pjax:send", function() {
+      equal(frame.location.pathname, "/dinosaurs.html")
+      start()
+    })
+
+    frame.$("a[href='/dinosaurs.html']").click()
+  })
+
+  asyncTest("preserves current url", function() {
+    var frame = this.frame
+
+    frame.$("#main").pjax("a", {preserveURL: true}).on("pjax:send", function() {
+      equal(frame.location.pathname, "/home.html")
+      start()
+    })
+
+    frame.$("a[href='/dinosaurs.html']").click()
+  })
+
   asyncTest("replaces container html from response data", function() {
     var frame = this.frame
 

--- a/test/unit/pjax.js
+++ b/test/unit/pjax.js
@@ -30,6 +30,33 @@ if ($.support.pjax) {
     })
   })
 
+  asyncTest("pushes new url right after sending request", function() {
+    var frame = this.frame
+
+    frame.$('#main').on('pjax:send', function() {
+      equal(frame.location.pathname, "/env.html")
+      start()
+    })
+    frame.$.pjax({
+      url: "env.html",
+      container: "#main"
+    })
+  })
+
+  asyncTest("preserves current url", function() {
+    var frame = this.frame
+
+    frame.$('#main').on('pjax:send', function() {
+      equal(frame.location.pathname, "/home.html")
+      start()
+    })
+    frame.$.pjax({
+      url: "env.html",
+      container: "#main",
+      preserveURL: true
+    })
+  })
+
   asyncTest("replaces container html from response data", function() {
     var frame = this.frame
 


### PR DESCRIPTION
Allows to preserve URL until response is received.
For example, on some `http://site.com/blog` is a link `http://site.com/refresh` which jush redirects back to `http://site.com/blog`.
If user clicks on `refresh` with pjax URL will change to `http://site.com/refresh` for a bit and then (on response) back to `http://site.com/blog`.
With this option URL will remain same during all refreshing.
