### PR TITLE
fix get fallback

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -502,6 +502,9 @@ function fallbackPjax(options) {
   }
 
   var data = options.data
+  if (!data && method === 'GET' && url.indexOf('?') != -1) {
+    data = url.match(/\?(.+)$/)[1]
+  }
   if (typeof data === 'string') {
     $.each(data.split('&'), function(index, value) {
       var pair = value.split('=')


### PR DESCRIPTION
This fix a problem when `GET` method comes to `fallbackPjax`.
Usually in `GET` method, we tend to use 

```
{
    url: '/?a=1&b=2'
} 
```

rather than 

```
{
    url: '/', 
    data: 'a=1&b=2'
}
```

But any parameters written in `action` attribute of `<form>` element with `GET` method will be ignored. 
e.g. 

```
<form action="/?a=1&b=2" method='GET'>
```

is equivalent to 

```
<form action="/' method='GET'>
```

Thus we need to add these parameters using hidden `input`.
