### PR TITLE
Add native support beforeSend and fix for asynchronous requests

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -287,6 +287,7 @@ function pjax(options) {
       state: pjax.state,
       previousState: previousState
     })
+	executeScriptTags(container.scripts)
     context.html(container.contents)
 
     // FF bug: Won't autofocus fields that are inserted via JS.
@@ -298,8 +299,6 @@ function pjax(options) {
     if (autofocusEl && document.activeElement !== autofocusEl) {
       autofocusEl.focus();
     }
-
-    executeScriptTags(container.scripts)
 
     // Scroll to top by default
     if (typeof options.scrollTo === 'number')
@@ -729,7 +728,12 @@ function executeScriptTags(scripts) {
     var script = document.createElement('script')
     script.type = $(this).attr('type')
     script.src = $(this).attr('src')
-    document.head.appendChild(script)
+	if(pjax.options.async) {	
+		document.head.appendChild(script)
+	}
+	else {
+		$(document.body).append(script)
+	}
   })
 }
 

--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -187,6 +187,12 @@ function pjax(options) {
   }
 
   var timeoutTimer
+  
+  if(typeof options.beforeSend === 'function'){
+	if(!options.beforeSend()) {
+		return false;
+	}
+  };
 
   options.beforeSend = function(xhr, settings) {
     // No timeout for non-GET requests


### PR DESCRIPTION
Two commits:
1. Native support beforeSend
Example:
```java
$.pjax({
     beforeSend: function(e, object) {
            // some scripts
            return true;
     },
     container: "[data-pjax-container]",
});
```
2. adding a script tag, depending on the type of request
Example:
```java
$.pjax({
     async: true, // by default
     container: "[data-pjax-container]",
});
```
will append script tag asynchronously

```java
$.pjax({
     async: false,
     container: "[data-pjax-container]",
});
```
will append script tag synchronously
