### PR TITLE
Don't break the back button when hard loading

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -383,7 +383,7 @@ function pjaxReload(container, options) {
 //
 // Returns nothing.
 function locationReplace(url) {
-  window.history.replaceState(null, "", "#")
+  window.history.replaceState(null, "", pjax.state.url)
   window.location.replace(url)
 }
 

--- a/test/app.rb
+++ b/test/app.rb
@@ -83,6 +83,11 @@ get '/boom.html' do
   erb :boom, :layout => !pjax?
 end
 
+get '/boom_sans_pjax.html' do
+  status 500
+  erb :boom_sans_pjax, :layout => false
+end
+
 get '/:page.html' do
   erb :"#{params[:page]}", :layout => !pjax?
 end

--- a/test/unit/pjax.js
+++ b/test/unit/pjax.js
@@ -1117,4 +1117,29 @@ if ($.support.pjax) {
       })
     })
   })
+
+  asyncTest("handles going back to page after loading an error page", function() {
+    var frame = this.frame
+    var iframe = this.iframe
+
+    equal(frame.location.pathname, "/home.html")
+    equal(frame.document.title, "Home")
+
+    $(iframe).one("load", function() {
+
+      window.iframeLoad = function() {
+        equal(frame.location.pathname, "/home.html")
+        equal(frame.document.title, "Home")
+
+        start()
+      }
+
+      frame.history.back()
+    })
+
+    frame.$.pjax({
+      url: "boom_sans_pjax.html",
+      container: "#main"
+    })
+  })
 }

--- a/test/views/boom_sans_pjax.erb
+++ b/test/views/boom_sans_pjax.erb
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>500 sans pjax</title>
+</head>
+<body>
+  <div id="main">
+    <p>500 sans pjax</p>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
- Add a test case for going back from error pages which don't have pjax,
  as described in issue #422
- When hard loading a url, set the back action to the page's url from
  before the request was made

Fixes #422
