### PR TITLE
File support by using FormData

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -131,7 +131,9 @@ function handleSubmit(event, container, options) {
   var defaults = {
     type: form.method.toUpperCase(),
     url: form.action,
-    data: $(form).serializeArray(),
+    data: new FormData( form ),
+    processData: false,
+    contentType: false,
     container: $(form).attr('data-pjax'),
     target: form
   }


### PR DESCRIPTION
Add file upload through a Pjax form by using FormData object. 
