### PR TITLE
Added check for cross origin call

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -179,6 +179,12 @@ function pjax(options) {
   if ($.isFunction(options.url)) {
     options.url = options.url()
   }
+  
+  // Ignore cross origin links
+  if (location.protocol !== parseURL(options.url).protocol || location.hostname !== parseURL(options.url).hostname) {
+    location.href = options.url;
+    return;
+  }
 
   var target = options.target
 


### PR DESCRIPTION
Default to location.href if the call is to cross origin url. Fixes #449
