### PR TITLE
Added default option of "fragment" to equal "body"

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -852,7 +852,8 @@ function enable() {
     dataType: 'html',
     scrollTo: 0,
     maxCacheLength: 20,
-    version: findVersion
+    version: findVersion,
+	fragment: 'body'
   }
   $(window).on('popstate.pjax', onPjaxPopstate)
 }


### PR DESCRIPTION
Documentation says that if "fragment" left empty, it will equal "body" - but its not. And if no fragment given, jquery-pjax will ignore "title" and "data-title" attributes (as of line 686) and the title wont be changed.