### PR TITLE
remove calling of the idiot executeScriptTags

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -307,8 +307,6 @@ function pjax(options) {
       autofocusEl.focus();
     }
 
-    executeScriptTags(container.scripts)
-
     // Scroll to top by default
     if (typeof options.scrollTo === 'number')
       $(window).scrollTop(options.scrollTo)
@@ -714,7 +712,7 @@ function extractContainer(data, xhr, options) {
     obj.contents.find('title').remove()
 
     // Gather all script[src] elements
-    obj.scripts = findAll(obj.contents, 'script[src]').remove()
+    obj.scripts = findAll(obj.contents, 'script[src]')
     obj.contents = obj.contents.not(obj.scripts)
   }
 


### PR DESCRIPTION
fixes
https://github.com/defunkt/jquery-pjax/issues/416
https://github.com/defunkt/jquery-pjax/issues/478
https://github.com/defunkt/jquery-pjax/issues/469
https://github.com/defunkt/jquery-pjax/issues/331
https://github.com/defunkt/jquery-pjax/issues/242

and there may be a lot more.

referenced
https://github.com/defunkt/jquery-pjax/pull/446
https://github.com/defunkt/jquery-pjax/pull/400
https://github.com/defunkt/jquery-pjax/pull/257