### PR TITLE
Cope with array form data in fallback

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -521,6 +521,10 @@ function fallbackPjax(options) {
       var pair = value.split('=')
       form.append($('<input>', {type: 'hidden', name: pair[0], value: pair[1]}))
     })
+  } else if ($.isArray(data)) {
+    $.each(data, function(index, value) {
+      form.append($('<input>', {type: 'hidden', name: value.name, value: value.value}))
+    })
   } else if (typeof data === 'object') {
     for (key in data)
       form.append($('<input>', {type: 'hidden', name: key, value: data[key]}))

--- a/test/unit/pjax_fallback.js
+++ b/test/unit/pjax_fallback.js
@@ -313,6 +313,50 @@ asyncTest("POST with data object"+s, function() {
   })
 })
 
+asyncTest("GET with data array"+s, function() {
+  var frame = this.frame
+
+  this.loaded = function() {
+    equal(frame.location.pathname, "/env.html")
+    equal(frame.location.search, "?foo=bar")
+
+    var env = JSON.parse(frame.$("#env").text())
+    equal(env['REQUEST_METHOD'], "GET")
+    equal(env['rack.request.query_hash']['foo'], 'bar')
+
+    start()
+  }
+
+  frame.$.pjax({
+    type: 'GET',
+    url: "env.html",
+    data: [{name: "foo", value: "bar"}],
+    container: "#main"
+  })
+})
+
+asyncTest("POST with data array"+s, function() {
+  var frame = this.frame
+
+  this.loaded = function() {
+    equal(frame.location.pathname, "/env.html")
+    equal(frame.location.search, "")
+
+    var env = JSON.parse(frame.$("#env").text())
+    equal(env['REQUEST_METHOD'], "POST")
+    equal(env['rack.request.form_hash']['foo'], 'bar')
+
+    start()
+  }
+
+  frame.$.pjax({
+    type: 'POST',
+    url: "env.html",
+    data: [{name: "foo", value: "bar"}],
+    container: "#main"
+  })
+})
+
 asyncTest("GET with data string"+s, function() {
   var frame = this.frame
 

--- a/test/unit/pjax_fallback.js
+++ b/test/unit/pjax_fallback.js
@@ -318,11 +318,13 @@ asyncTest("GET with data array"+s, function() {
 
   this.loaded = function() {
     equal(frame.location.pathname, "/env.html")
-    equal(frame.location.search, "?foo=bar")
+    equal(frame.location.search, "?foo%5B%5D=bar&foo%5B%5D=baz")
 
     var env = JSON.parse(frame.$("#env").text())
     equal(env['REQUEST_METHOD'], "GET")
-    equal(env['rack.request.query_hash']['foo'], 'bar')
+    var expected = {'foo': ['bar', 'baz']};
+    if (!disabled) expected._pjax = "#main"
+    deepEqual(env['rack.request.query_hash'], expected)
 
     start()
   }
@@ -330,7 +332,7 @@ asyncTest("GET with data array"+s, function() {
   frame.$.pjax({
     type: 'GET',
     url: "env.html",
-    data: [{name: "foo", value: "bar"}],
+    data: [{name: "foo[]", value: "bar"}, {name: "foo[]", value: "baz"}],
     container: "#main"
   })
 })
@@ -344,7 +346,9 @@ asyncTest("POST with data array"+s, function() {
 
     var env = JSON.parse(frame.$("#env").text())
     equal(env['REQUEST_METHOD'], "POST")
-    equal(env['rack.request.form_hash']['foo'], 'bar')
+    var expected = {'foo': ['bar', 'baz']};
+    if (!disabled) expected._pjax = "#main"
+    deepEqual(env['rack.request.form_hash'], expected)
 
     start()
   }
@@ -352,7 +356,7 @@ asyncTest("POST with data array"+s, function() {
   frame.$.pjax({
     type: 'POST',
     url: "env.html",
-    data: [{name: "foo", value: "bar"}],
+    data: [{name: "foo[]", value: "bar"}, {name: "foo[]", value: "baz"}],
     container: "#main"
   })
 })


### PR DESCRIPTION
IE9 currently breaks when trying to submit form data as it goes through the fall back which can't cope with jquery's serializeArray style form data. This fixes the fallback's form generator to correctly interpret array form data.