### PR TITLE
Strip jQuery's cache-busting parameter

### DIFF
--- a/test/unit/pjax.js
+++ b/test/unit/pjax.js
@@ -22,11 +22,13 @@ if ($.support.pjax) {
 
     frame.$('#main').on('pjax:success', function() {
       equal(frame.location.pathname, "/hello.html")
+      equal(frame.location.search, "")
       start()
     })
     frame.$.pjax({
       url: "hello.html",
-      container: "#main"
+      container: "#main",
+      cache: false
     })
   })
 


### PR DESCRIPTION
If jQuery `cache: false` ajax parameter is set, the `&_=<TIMESTAMP>` param will have been appended to the request URL. Because this URL will eventually be used to replace the page URL, we need to ensure that we're stripping the cache-busting parameter before that, like we do with the "_pjax" internal parameter as well.

Fixes #490