### PR TITLE
Use pageYOffset over scrollY for IE9+ support

### DIFF
--- a/test/unit/pjax.js
+++ b/test/unit/pjax.js
@@ -92,10 +92,10 @@ if ($.support.pjax) {
     var frame = this.frame
 
     frame.window.scrollTo(0, 100)
-    equal(frame.window.scrollY, 100)
+    equal(frame.window.pageYOffset, 100)
 
     frame.$('#main').on('pjax:success', function() {
-      equal(frame.window.scrollY, 0)
+      equal(frame.window.pageYOffset, 0)
       start()
     })
     frame.$.pjax({
@@ -108,10 +108,10 @@ if ($.support.pjax) {
     var frame = this.frame
 
     frame.window.scrollTo(0, 100)
-    equal(frame.window.scrollY, 100)
+    equal(frame.window.pageYOffset, 100)
 
     frame.$('#main').on('pjax:success', function() {
-      equal(frame.window.scrollY, 100)
+      equal(frame.window.pageYOffset, 100)
       start()
     })
     frame.$.pjax({
@@ -943,11 +943,11 @@ if ($.support.pjax) {
     equal(frame.location.pathname, "/home.html")
 
     frame.window.scrollTo(0, 100)
-    equal(frame.window.scrollY, 100)
+    equal(frame.window.pageYOffset, 100)
 
     frame.$("#main").on("pjax:complete", function() {
       equal(frame.location.pathname, "/long.html")
-      equal(frame.window.scrollY, 0)
+      equal(frame.window.pageYOffset, 0)
 
       ok(frame.history.length > 1)
       goBack(frame, function() {
@@ -955,7 +955,7 @@ if ($.support.pjax) {
 
         // PENDING: Popstate scroll position restore doesn't seem to
         // work inside an iframe.
-        // equal(frame.window.scrollY, 100)
+        // equal(frame.window.pageYOffset, 100)
 
         start()
       })

--- a/test/unit/pjax_fallback.js
+++ b/test/unit/pjax_fallback.js
@@ -107,10 +107,10 @@ asyncTest("scrolls to top of the page"+s, function() {
   var frame = this.frame
 
   frame.window.scrollTo(0, 100)
-  equal(frame.window.scrollY, 100)
+  equal(frame.window.pageYOffset, 100)
 
   this.loaded = function(frame) {
-    equal(frame.window.scrollY, 0)
+    equal(frame.window.pageYOffset, 0)
     start()
   }
 
@@ -123,13 +123,13 @@ asyncTest("scrolls to top of the page"+s, function() {
 asyncTest("scrolls to anchor at top page"+s, function() {
   var frame = this.frame
 
-  equal(frame.window.scrollY, 0)
+  equal(frame.window.pageYOffset, 0)
 
   this.loaded = function(frame) {
     setTimeout(function() {
       equal(frame.location.pathname, "/anchor.html")
       equal(frame.location.hash, "#top")
-      equal(frame.window.scrollY, 8)
+      equal(frame.window.pageYOffset, 8)
       start()
     }, 100)
   }
@@ -151,11 +151,11 @@ asyncTest("scrolls to anchor at top page"+s, function() {
 asyncTest("empty anchor doesn't scroll page"+s, function() {
   var frame = this.frame
 
-  equal(frame.window.scrollY, 0)
+  equal(frame.window.pageYOffset, 0)
 
   this.loaded = function(frame) {
     setTimeout(function() {
-      equal(frame.window.scrollY, 0)
+      equal(frame.window.pageYOffset, 0)
       start()
     }, 10)
   }
@@ -169,11 +169,11 @@ asyncTest("empty anchor doesn't scroll page"+s, function() {
 asyncTest("scrolls to anchor at bottom page"+s, function() {
   var frame = this.frame
 
-  equal(frame.window.scrollY, 0)
+  equal(frame.window.pageYOffset, 0)
 
   this.loaded = function(frame) {
     setTimeout(function() {
-      equal(frame.window.scrollY, 10008)
+      equal(frame.window.pageYOffset, 10008)
       start()
     }, 10)
   }
@@ -187,11 +187,11 @@ asyncTest("scrolls to anchor at bottom page"+s, function() {
 asyncTest("scrolls to named encoded anchor"+s, function() {
   var frame = this.frame
 
-  equal(frame.window.scrollY, 0)
+  equal(frame.window.pageYOffset, 0)
 
   this.loaded = function(frame) {
     setTimeout(function() {
-      equal(frame.window.scrollY, 10008)
+      equal(frame.window.pageYOffset, 10008)
       start()
     }, 10)
   }


### PR DESCRIPTION
``window.pageYOffset`` predates ``window.scrollY`` and is supported in more browsers – specifically IE9+. There are still broken tests in IE, but this is a start.