### PR TITLE
Don't replace ampersands in X-PJAX-URLs

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -576,7 +576,6 @@ function stripParam(url, name) {
   return url
     .replace(new RegExp('[?&]' + name + '=[^&#]*'), '')
     .replace(/[?&]($|#)/, '\1')
-    .replace(/[?&]/, '?')
 }
 
 function stripInternalParams(url) {

--- a/test/app.rb
+++ b/test/app.rb
@@ -93,3 +93,7 @@ end
 get '/:page.html' do
   erb :"#{params[:page]}", :layout => !pjax?
 end
+
+get '/some-&-path/hello.html' do
+  erb :hello, :layout => !pjax?
+end

--- a/test/unit/pjax.js
+++ b/test/unit/pjax.js
@@ -32,6 +32,22 @@ if ($.support.pjax) {
     })
   })
 
+  asyncTest("copes with ampersands when pushing urls", function() {
+    var frame = this.frame
+
+    frame.$('#main').on('pjax:success', function() {
+      console.log(frame.location.pathname)
+      equal(frame.location.pathname, "/some-&-path/hello.html")
+      equal(frame.location.search, "")
+      start()
+    })
+    frame.$.pjax({
+      url: "/some-&-path/hello.html",
+      container: "#main",
+      cache: false
+    })
+  })
+
   asyncTest("replaces container html from response data", function() {
     var frame = this.frame
 

--- a/test/unit/pjax.js
+++ b/test/unit/pjax.js
@@ -32,19 +32,17 @@ if ($.support.pjax) {
     })
   })
 
-  asyncTest("copes with ampersands when pushing urls", function() {
+  asyncTest("compatible with pathnames that contain an ampersand", function() {
     var frame = this.frame
 
     frame.$('#main').on('pjax:success', function() {
-      console.log(frame.location.pathname)
       equal(frame.location.pathname, "/some-&-path/hello.html")
       equal(frame.location.search, "")
       start()
     })
     frame.$.pjax({
       url: "/some-&-path/hello.html",
-      container: "#main",
-      cache: false
+      container: "#main"
     })
   })
 


### PR DESCRIPTION
Urls containing ampersands, for example http://www.foo.com/some-&-path were getting their ampersand replaced with a ?.

I've put my reasoning for the change in the commit message, I'd like make sure there's no behaviour that I'm breaking here.