### PR TITLE
add beforeReplace option

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ key | default | description
 `timeout` | 650 | ajax timeout in milliseconds after which a full refresh is forced
 `push` | true | use [pushState][] to add a browser history entry upon navigation
 `replace` | false | replace URL without adding browser history entry
+`beforeReplace` | false | function returning the alter content before appending to the DOM
 `maxCacheLength` | 20 | maximum cache size for previous container contents
 `version` | | a string or function returning the current pjax version
 `scrollTo` | 0 | vertical position to scroll to after navigation. To avoid changing scroll position, pass `false`.

--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -175,6 +175,8 @@ function pjax(options) {
     options.url = options.url()
   }
 
+  $.pjax.beforeReplace = $.isFunction(options.beforeReplace) ? options.beforeReplace : false
+
   var target = options.target
 
   var hash = parseURL(options.url).hash
@@ -303,7 +305,16 @@ function pjax(options) {
       state: pjax.state,
       previousState: previousState
     })
-    context.html(container.contents)
+
+    var contents = container.contents
+    var replaced = false
+
+    // Editing contents before it's inserted onto the page.
+    if ($.pjax.beforeReplace) {
+      replaced = $.pjax.beforeReplace(contents, options)
+    }
+
+    context.html(replaced || contents)
 
     // FF bug: Won't autofocus fields that are inserted via JS.
     // This behavior is incorrect. So if theres no current focus, autofocus
@@ -479,8 +490,15 @@ function onPjaxPopstate(event) {
           previousState: previousState
         })
         container.trigger(beforeReplaceEvent, [contents, options])
-        container.html(contents)
 
+        var replaced = false
+
+        // Editing contents before it's inserted onto the page.
+        if ($.pjax.beforeReplace) {
+          replaced = $.pjax.beforeReplace(contents, options);
+        }
+
+        container.html(replaced || contents)
         container.trigger('pjax:end', [null, options])
       } else {
         pjax(options)
@@ -878,6 +896,7 @@ function enable() {
   $.pjax.click = handleClick
   $.pjax.submit = handleSubmit
   $.pjax.reload = pjaxReload
+  $.pjax.beforeReplace = false;
   $.pjax.defaults = {
     timeout: 650,
     push: true,

--- a/test/views/replace.erb
+++ b/test/views/replace.erb
@@ -1,0 +1,3 @@
+<%= title 'Replace' %>
+
+<h1>Hello, <span class="placeUsernameHere">Guest</span>!</h1>


### PR DESCRIPTION
Idea from #274 issue.

Tried to add a beforeRequest option (function) to change HTML before appending it to the DOM. 

I use jquery-pjax in my laravel5/angular application and I need to [$compile](https://docs.angularjs.org/api/ng/service/$compile) HTML before insert it to the DOM. It's my first experience with jquery-pjax. So, maybe it's not right way, especially solution to provide **beforeRequest** option to **onPjaxPopstate()** (back/forward). But it's working fine for me now. Probably, it would be useful.