### PR TITLE
only add the hash if it is not empty

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -226,7 +226,9 @@ function pjax(options) {
     }
 
     var url = parseURL(settings.url)
-    url.hash = hash
+    if(hash){
+      url.hash = hash
+    }
     options.requestUrl = stripInternalParams(url.href)
   }
 


### PR DESCRIPTION
on options.beforeSend check if there is a hash to prevent the extra # on URLs without hash