### PR TITLE
Change internal cache struct to fix restoring mixed containers

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -424,14 +424,13 @@ function onPjaxPopstate(event) {
 
   var previousState = pjax.state
   var state = event.state
+  var direction
 
   if (state && state.container) {
     // When coming forward from a separate history session, will get an
     // initial pop with a state we are already at. Skip reloading the current
     // page.
     if (initialPop && initialURL == state.url) return
-
-    var direction, containerSelector = state.container
 
     if (previousState) {
       // If popping back to the same state, just skip.
@@ -440,13 +439,12 @@ function onPjaxPopstate(event) {
 
       // Since state IDs always increase, we can deduce the navigation direction
       direction = previousState.id < state.id ? 'forward' : 'back'
-      if (direction == 'back') containerSelector = previousState.container
     }
 
-    var container = $(containerSelector)
-    if (container.length) {
-      var contents = cacheMapping[state.id]
+    var cache = cacheMapping[state.id] || []
+    var container = $(cache[0] || state.container), contents = cache[1]
 
+    if (container.length) {
       if (previousState) {
         // Cache current container before replacement and inform the
         // cache which direction the history shifted.
@@ -564,7 +562,7 @@ function cloneContents(container) {
   cloned.find('script').each(function(){
     if (!this.src) jQuery._data(this, 'globalEval', false)
   })
-  return cloned.contents()
+  return [container.selector, cloned.contents()]
 }
 
 // Internal: Strips named query param from url

--- a/test/unit/pjax.js
+++ b/test/unit/pjax.js
@@ -253,7 +253,7 @@ if ($.support.pjax) {
     }, 0)
   })
 
-  asyncTest("mixed containers", 4, function() {
+  asyncTest("mixed containers", 6, function() {
     navigate(this.frame)
     .pjax({ url: "fragment.html", container: "#main" })
     .pjax({ url: "aliens.html", container: "#foo" }, function(frame) {
@@ -261,6 +261,11 @@ if ($.support.pjax) {
     })
     .back(-1, function(frame) {
       equal(frame.$("#main > #foo").text().trim(), "Foo")
+    })
+    .pjax({ url: "env.html", replace: true, fragment: "#env", container: "#bar" }, function(frame) {
+      // This replaceState shouldn't affect restoring other popstates
+      equal(frame.$("#main > #foo").text().trim(), "Foo")
+      ok(JSON.parse(frame.$("#bar").text()))
     })
     .back(-1, function(frame) {
       equal(frame.$("#main > ul > li").first().text(), "home")


### PR DESCRIPTION
When different pjax containers were used for pjax navigations, the popstate restoring mechanism would get confused as to in which container to restore some particular HTML. I tried to remedy this by reading the target container from `previousState` on "back" navigations, however this was subject to at least a couple of flaws.

This adds the container selector information to the cache, forming a pair with cached contents for each history entry.