### PR TITLE
Cache before executing JS option

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ key | default | description
 ----|---------|------------
 `timeout` | 650 | ajax timeout in milliseconds after which a full refresh is forced
 `push` | true | use [pushState][] to add a browser history entry upon navigation
+`cacheBeforeEval` | false | cache HTML received from the server before executing JS
 `replace` | false | replace URL without adding browser history entry
 `maxCacheLength` | 20 | maximum cache size for previous container contents
 `version` | | a string or function returning the current pjax version

--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -202,6 +202,8 @@ function pjax(options) {
 
   var timeoutTimer
 
+  var preEvalCache = []
+
   options.beforeSend = function(xhr, settings) {
     // No timeout for non-GET requests
     // Its not safe to request the resource again with a fallback method.
@@ -315,6 +317,11 @@ function pjax(options) {
       autofocusEl.focus();
     }
 
+    if (options.cacheBeforeEval) {
+      // cache container element before executing JS
+      preEvalCache.push(pjax.state.id, cloneContents(context))
+    }
+
     executeScriptTags(container.scripts)
 
     var scrollTo = options.scrollTo
@@ -357,7 +364,11 @@ function pjax(options) {
   if (xhr.readyState > 0) {
     if (options.push && !options.replace) {
       // Cache current container element before replacing it
-      cachePush(pjax.state.id, cloneContents(context))
+      if (options.cacheBeforeEval) {
+        cachePush(preEvalCache[0], preEvalCache[1])
+      } else {
+        cachePush(pjax.state.id, cloneContents(context))
+      }
 
       window.history.pushState(null, "", options.requestUrl)
     }
@@ -869,6 +880,7 @@ function enable() {
   $.pjax.defaults = {
     timeout: 650,
     push: true,
+    cacheBeforeEval: false,
     replace: false,
     type: 'GET',
     dataType: 'html',


### PR DESCRIPTION
Many jQuery plugins require certain markup to initialize themselves, afterwards changing that markup. This doesn't pose a problem when navigating "forward" (for example 1 -> 2 -> 3 -> 4), but since pjax caches the html only after evaluating JS, _using the back/forward_ button breaks the functionality of these plugins (for example, going 4 -> 3 -> 2 -> 3 doesn't work properly).

Using the `{cacheBeforeEval: true}` option, pjax will cache the HTML received from the server **BEFORE** executing JS, preserving the original markup and allowing the plugins to initialize themselves cleanly.

The default value is: `{cacheBeforeEval: false}` (the default behavior remains unchanged).
