### PR TITLE
Add blurFocus option to disable bluring the focus of existing elements.

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -292,10 +292,15 @@ function pjax(options) {
       window.history.replaceState(pjax.state, container.title, container.url)
     }
 
+    // Only blur the focus if the focused element is within the container.
+    var blurFocus = $.contains(options.container, document.activeElement)
+
     // Clear out any focused controls before inserting new page contents.
-    try {
-      document.activeElement.blur()
-    } catch (e) { }
+    if (blurFocus) {
+      try {
+        document.activeElement.blur()
+      } catch (e) { }
+    }
 
     if (container.title) document.title = container.title
 


### PR DESCRIPTION
This change adds a `blurFocus` option that disables the focus blurring that occurs on existing elements when loading content. This can be useful if using PJAX to reload the contents of a search page, for instance.

Multiple other people requested this feature [back in 2013 when the blurring was introduced](https://github.com/defunkt/jquery-pjax/pull/300#commitcomment-3621248), and additionally so [on a fork](https://github.com/yiisoft/jquery-pjax/issues/19) of your project.