### PR TITLE
Event "pjax:beforeApply" to update options

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -275,7 +275,7 @@ function pjax(options) {
 
     var latestVersion = xhr.getResponseHeader('X-PJAX-Version')
 
-    fire('pjax:updateOptions', [data, updateOptions], {})
+    fire('pjax:beforeApply', [data, updateOptions], {})
 
     var container = extractContainer(data, xhr, options)
 

--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -275,7 +275,7 @@ function pjax(options) {
 
     var latestVersion = xhr.getResponseHeader('X-PJAX-Version')
 
-    fire('pjax:beforeApply', [data, updateOptions], {})
+    fire('pjax:beforeApply', [xhr, data, updateOptions], {})
 
     var container = extractContainer(data, xhr, options)
 


### PR DESCRIPTION
This PR is a simple proposal to add a `pjax:beforeApply` event, which let us change the container (and some others options) according to the content returned by the AJAX request.

I'm using this to load content into different containers: main page and modals. A modal is just some content displayed on top of the main page without changing the page's url. So we have a static website that looks dynamic by remotely loading modals.

I understand that it's probably not an intended usage of pjax.

#### Example:

```html
<body>
    <div id="pjax-container"></div>
    <div id="modals-container"></div>
</body>
```

```js
$(document).pjax('a', '#pjax-container')
.on('pjax:beforeApply', function(e, xhr, content, updateOptions) {
    var isModal = xhr.getResponseHeader('X-PJAX-IsModal');

    if (isModal) {
        updateOptions({
            container: "#modals-container",
            push: false
        });
    }
});
```

#### Current solution: bind with different options

The current solution is to apply pjax according to an attribute:

```js
$(document).pjax('a[data-pjax!=modal]', '#pjax-container');
$(document).pjax('a[data-pjax=modal]', '#pjax-modal', {
    push: false
});
```

The issue with this solution is to ensure that all links have the correct target (`data-pjax`). Also it doesn't work for submitting a form in a modal (`data-pjax=modal`) that causes a redirection for the main page (the redirected content will be displayed in the modal container).

