### PR TITLE
Fix submit of form with input[name=action]

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -118,15 +118,16 @@ function handleClick(event, container, options) {
 function handleSubmit(event, container, options) {
   options = optionsFor(container, options)
 
-  var form = event.currentTarget
+  var form = event.currentTarget;
+  var $form = $(form);
 
   if (form.tagName.toUpperCase() !== 'FORM')
     throw "$.pjax.submit requires a form element"
 
   var defaults = {
     type: form.method.toUpperCase(),
-    url: form.action,
-    container: $(form).attr('data-pjax'),
+    url: $form.attr('action'),
+    container: $form.attr('data-pjax'),
     target: form
   }
 

--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -125,7 +125,7 @@ function handleSubmit(event, container, options) {
     throw "$.pjax.submit requires a form element"
 
   var defaults = {
-    type: form.method.toUpperCase(),
+    type: ($form.attr('method') || 'GET').toUpperCase(),
     url: $form.attr('action'),
     container: $form.attr('data-pjax'),
     target: form

--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -118,8 +118,8 @@ function handleClick(event, container, options) {
 function handleSubmit(event, container, options) {
   options = optionsFor(container, options)
 
-  var form = event.currentTarget;
-  var $form = $(form);
+  var form = event.currentTarget
+  var $form = $(form)
 
   if (form.tagName.toUpperCase() !== 'FORM')
     throw "$.pjax.submit requires a form element"


### PR DESCRIPTION
If you have a form like:

```html
<form action="/test" method="POST">
     <button name="action" value="hello">Hello</button>
     <button name="action" value="world">World</button> 
</form>
```

The form will be submitted to `/[object%20NodeList]` since `form.action` is equal to the NodeList of buttons.

This PR fixes it by using the attribute value instead of `form.action`.

Related: http://stackoverflow.com/questions/1378155/reading-form-action-property-in-ie6-if-form-has-a-field-named-action