### PR TITLE
Move cache pop after triggering of popstate event

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -451,17 +451,17 @@ function onPjaxPopstate(event) {
     var container = $(containerSelector), contents = cache[1]
 
     if (container.length) {
-      if (previousState) {
-        // Cache current container before replacement and inform the
-        // cache which direction the history shifted.
-        cachePop(direction, previousState.id, [containerSelector, cloneContents(container)])
-      }
-
       var popstateEvent = $.Event('pjax:popstate', {
         state: state,
         direction: direction
       })
       container.trigger(popstateEvent)
+
+      if (previousState) {
+        // Cache current container before replacement and inform the
+        // cache which direction the history shifted.
+        cachePop(direction, previousState.id, [containerSelector, cloneContents(container)])
+      }
 
       var options = {
         id: state.id,


### PR DESCRIPTION
This PR allow the 'destroying' of plugins that require restoration of DOM.

Indeed some plugins like Select2, Footable, Bootstrap Dropdown, modify the DOM in deep for their initialization, but also to use (dropdown in open state), and must be properly destroy to every page change.

The problem does not occur with pages that are not cached, because the destroying of plugins may be performed on the event `pjax: beforeSend`.

However, this isn't the case with the `pjax: popstate` event, and this PR solves this problem.
