### PR TITLE
Add package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "jquery-pjax",
+  "version": "1.9.6",
+  "description": "pushState + ajax = pjax",
+  "main": "jquery.pjax.js",
+  "directories": {
+    "test": "test"
+  },
+  "scripts": {
+    "test": "script/test"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/defunkt/jquery-pjax.git"
+  },
+  "keywords": ["jquery", "pjax"],
+  "author": "Chris Wanstrath <chris@github.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/defunkt/jquery-pjax/issues"
+  },
+  "homepage": "https://github.com/defunkt/jquery-pjax#readme"
+}


### PR DESCRIPTION
This adds a package.json to jquery-pjax since the [jquery plugin registry is no longer writable and instead recommends npm](https://plugins.jquery.com/). A `"main"` field is added so that jquery-pjax can be loaded by module bundlers like browserify and webpack simply with `require('jquery-pjax')`.

An `npm publish` afterwards would be fantastic.
