### PR TITLE
Fix a bug which ignores hash in X-PJAX-URL

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -326,8 +326,8 @@ function pjax(options) {
     var scrollTo = options.scrollTo
 
     // Ensure browser scrolls to the element referenced by the URL anchor
-    if (hash) {
-      var name = decodeURIComponent(hash.slice(1))
+    if (url.hash) {
+      var name = decodeURIComponent(url.hash.slice(1))
       var target = document.getElementById(name) || document.getElementsByName(name)[0]
       if (target) scrollTo = $(target).offset().top
     }


### PR DESCRIPTION
Hash in the `X-PJAX-URL` header should be treated as a common anchor linking. The original code is almost there.