### PR TITLE
Make compatible with browserify

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -4,7 +4,14 @@
  * https://github.com/defunkt/jquery-pjax
  */
 
-(function($){
+(function(factory) {
+    if (typeof module === "object" && typeof module.exports === "object") {
+        factory(require("jquery"), window, document);
+    }
+    else {
+        factory(jQuery, window, document);
+    }
+} (function($, window, document, undefined) {
 
 // When called on a container with a selector, fetches the href with
 // ajax into the container or with the data-pjax attribute on the link
@@ -922,4 +929,4 @@ $.support.pjax =
 
 $.support.pjax ? enable() : disable()
 
-})(jQuery);
+}));


### PR DESCRIPTION
Compatible with browserify, can be used as module.

Example:
- **App.js**

```
window.$ = window.jQuery = require('jquery');
require('./PjaxRequest');

```
- **PjaxRequest.js**

```
require('jquery-pjax/jquery.pjax');
export default function () {
    $.fn.PjaxRequest = function () {
        $(document).pjax("a", $(this),  {
            timeout: 15000
        });
        // Others event
        // ............
    }
    $('[data-pjax]').PjaxRequest();
};
module.exports = exports.default;
```
