### PR TITLE
Error when loading full html-document without <head> or with empty <head/>

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -697,8 +697,9 @@ function extractContainer(data, xhr, options) {
 
   // Attempt to parse response html into elements
   if (fullDocument) {
-    var $head = $(parseHTML(data.match(/<head[^>]*>([\s\S.]*)<\/head>/i)[0]))
     var $body = $(parseHTML(data.match(/<body[^>]*>([\s\S.]*)<\/body>/i)[0]))
+    var $head = data.match(/<head[^>]*>([\s\S.]*)<\/head>/i);
+    $head = ($head != null) ? $(parseHTML($head[0])) : $body;
   } else {
     var $head = $body = $(parseHTML(data))
   }


### PR DESCRIPTION
If the html loaded by pjax does start with an `<html>`-tag but does not contain a `<head>`\- or just an empty `<head/>`-tag, an error is thrown in extractContainer because the regex-match looking for content within `<head></head>`-tags does not match and returns `null` instead of an array.

As the HTML-Specification enforces (at least as i understand it) that an `<html>`-tag always has an `<head>` and a `<body>`-tag but `<head>` may be empty (`<title>` is optional "when a higher-level protocol provides title information"), it seems that pjax should be able to handle this situation.
