### PR TITLE
Support script tags with both src and contents

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -776,6 +776,7 @@ function executeScriptTags(scripts) {
     var type = $(this).attr('type')
     if (type) script.type = type
     script.src = $(this).attr('src')
+    $(script).html($(this).html());
     document.head.appendChild(script)
   })
 }


### PR DESCRIPTION
Although not officially part of the HTML spec, such scripts are used a lot, especially by Google.

See http://stackoverflow.com/questions/6528325/what-does-a-script-tag-with-src-and-content-mean for more details