### PR TITLE
remove extra ampersand in query string

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -575,8 +575,14 @@ function cloneContents(container) {
 //
 // Returns sanitized url.href String.
 function stripInternalParams(url) {
-  url.search = url.search.replace(/([?&])(_pjax|_)=[^&]*/g, '')
-  return url.href.replace(/\?($|#)/, '$1')
+
+  // Strip internal params and the preceding ampersands if not first in the query string
+  // (i.e. remove '&_pjax=asdf' from '?_=asdf&a=b&_pjax=asdf')
+  url.search = url.search.replace(/&(_pjax|_)=[^&]*/g, '')
+
+  // Strip internal param and following ampersand if first in the query string
+  // (i.e. remove '_=asdf&' from '?_=asdf&a=b')
+  url.search = url.search.replace(/(_pjax|_)=[^&]*&*/g, '')
 }
 
 // Internal: Parse URL components and returns a Locationish object.

--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -583,6 +583,7 @@ function stripInternalParams(url) {
   // Strip internal param and following ampersand if first in the query string
   // (i.e. remove '_=asdf&' from '?_=asdf&a=b')
   url.search = url.search.replace(/(_pjax|_)=[^&]*&*/g, '')
+  return url.href.replace(/\?($|#)/, '$1')
 }
 
 // Internal: Parse URL components and returns a Locationish object.


### PR DESCRIPTION
Fix for issue #637: https://github.com/defunkt/jquery-pjax/issues/637

First, strip internal params that aren’t the first url param (i.e. remove `&_pjax=asdf` from `?_=asdf&a=b&_pjax=asdf`)

Then, if the first url param is also an internal param, strip it and the ampersand following it. (i.e. remove `_=asdf&` from `?_=asdf&a=b`)

Unless case 2 is handled separately, there will be an extra ampersand in the query string when an internal param is also the first url param.

The issue that this commit fixes can unfortunately break pages by producing malformed query strings when multiple pjax calls happen.