### PR TITLE
Fix ‘Uncaught TypeError: a.compareDocumentPosition is not a function’

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -293,7 +293,7 @@ function pjax(options) {
     }
 
     // Only blur the focus if the focused element is within the container.
-    var blurFocus = $.contains(context, document.activeElement)
+    var blurFocus = $.contains(context.get(0), document.activeElement)
 
     // Clear out any focused controls before inserting new page contents.
     if (blurFocus) {


### PR DESCRIPTION
Fix for jQuery 1.8.0.

Related issues:
https://github.com/defunkt/jquery-pjax/issues/675
https://bugs.jquery.com/ticket/7297