### PR TITLE
Prefer direct matches over nested title-tags

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -681,7 +681,7 @@ function extractContainer(data, xhr, options) {
 
   // If there's a <title> tag in the header, use it as
   // the page's title.
-  obj.title = findAll($head, 'title').last().text()
+  obj.title = findAll($head, 'title').first().text()
 
   if (options.fragment) {
     var $fragment = $body


### PR DESCRIPTION
With this change we prefer top level title tags over deeply nested ones.

This fixes https://github.com/defunkt/jquery-pjax/issues/616