### PR TITLE
Adds trailing semicolon in order to avoid type errors.

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -900,4 +900,4 @@ if ($.support.pjax) {
   disable()
 }
 
-})(jQuery)
+})(jQuery);


### PR DESCRIPTION
A simple semicolon that makes sure projects with other libraries or Browserify know where this pjax begins and ends.

**Before**
![pjax_type_error](https://user-images.githubusercontent.com/12223613/36483389-e21d24a0-170d-11e8-96ea-501512f292a8.png)

**After the semicolon**
![pjax_running](https://user-images.githubusercontent.com/12223613/36483415-f7f7c334-170d-11e8-8aa1-852a46aafdc9.png)